### PR TITLE
All existing winston@2 formats. Finished README.md

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 winstonjs
+Copyright (c) 2017 Charlie Robbins & the Contributors.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -15,15 +15,54 @@ const alignedWithColorsAndTime = format.combine(
 );
 ```
 
-## Understanding formats
-
-Every format accepts the following 
-
 ## `info` Objects
 
-The `info` parameter provided to a given format represents a single log message. The object itself is mutable. `logform` itself exposes several properties  which means community formats could add 
+The `info` parameter provided to a given format represents a single log message. The object itself is mutable. Every `info` must have at least the `level` and `message` properties:
 
+``` js
+{
+  level: 'info',                 // Level of the logging message  
+  message: 'Hey! Log something?' // Descriptive message being logged.
+}
+```
 
+`logform` itself exposes several additional properties:
+
+- `splat`: string interpolation splat for `%d %s`-style messages.
+- `timestamp`: timestamp the message was received.
+- `label`: custom label associated with each message.
+
+As a consumer you may add whatever properties you wish – _internal state is maintained by `Symbol` properties._
+
+## Understanding formats
+
+Each format is designed to be as simple as possible. They may be combined with `format.combined`. To define a new format simple pass it a function:
+
+```
+const { format } = require('logform');
+
+const volume = format((info, opts) => {
+  if (opts.yell) {
+    info.message = info.message.toUpperCase(); 
+  } else if (opts.whisper) {
+    info.message = info.message.toLowerCase();
+  }
+
+  return info;
+});
+
+// `volume` is now a function that returns instances of the format.
+const scream = volume({ yell: true });
+console.dir({ 
+  level: 'info', 
+  message: `sorry for making you yell in your head!` 
+});
+
+// {
+//   level: 'info'
+//   message: 'SORRY FOR MAKING YOU YELL IN YOUR HEAD!'
+// }
+```
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,29 @@
 # logform
 
-An mutable object format designed for chaining & objectMode streams.
+An mutable object-based log format designed for chaining & objectMode streams.
 
 ## Usage
 
 ``` js
 const { format } = require('logform');
 
-const simpleColorized = format(
+const alignedWithColorsAndTime = format.combine(
   format.colorize(),
-  format.simple()
+  format.timestamp(),
+  format.align(),
+  format.printf(info => `${info.timestamp} ${info.level}: ${message}`)
 );
 ```
+
+## Understanding formats
+
+Every format accepts the following 
+
+## `info` Objects
+
+The `info` parameter provided to a given format represents a single log message. The object itself is mutable. `logform` itself exposes several properties  which means community formats could add 
+
+
 
 ## Tests
 

--- a/align.js
+++ b/align.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const format = require('./format');
+
+/*
+ * function align (opts)
+ * Returns a new instance of the align Format which adds a `\t`
+ * delimiter before the message to properly align it in the same place.
+ * It was previously { align: true } in winston < 3.0.0
+ */
+module.exports = format(function (info) {
+  info.message = '\t' + info.message;
+  return info;
+});

--- a/cli.js
+++ b/cli.js
@@ -2,7 +2,7 @@
 
 const format = require('./format');
 const colorize = require('./colorize');
-const padLevels = require('./padLevels');
+const padLevels = require('./pad-levels');
 
 /*
  * function cli (opts)

--- a/cli.js
+++ b/cli.js
@@ -1,13 +1,16 @@
 'use strict';
 
-var format = require('./format');
+const format = require('./format');
+const colorize = require('./colorize');
+const padLevels = require('./padLevels');
 
 /*
  * function cli (opts)
- * Returns a new instance of the CLI format TransformStream
- * with turns a log `info` object into the same format
- * previously available in `winston.cli()` in `winston < 3.0.0`.
+ * Returns a new instance of the CLI format that turns a log
+ * `info` object into the same format previously available
+ * in `winston.cli()` in `winston < 3.0.0`.
  */
-module.exports = format(function (info, opts) {
-  throw new Error('Not implemented.');
-});
+module.exports = format(
+  colorize(),
+  padLevels()
+);

--- a/colorize.js
+++ b/colorize.js
@@ -16,8 +16,9 @@ const hasSpace = /\s+/;
 
 /*
  * function colorize (opts)
- * Returns a new instance of the CLI format TransformStream
- * with applies level colors to `info` objects.
+ * Returns a new instance of the colorize Format that applies
+ * level colors to `info` objects. This was previously exposed
+ * as { colorize: true } to transports in `winston < 3.0.0`.
  */
 module.exports = function createColorize(opts) {
   return new Colorizer(opts);

--- a/combine.js
+++ b/combine.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const format = require('./format');
+
+/*
+ * function combine (opts)
+ * Returns a new instance of the combine Format which combines the specified
+ * formats into a new format. This is similar to a pipe-chain in transform streams.
+ * We choose to combine the prototypes this way because there is no back pressure in
+ * an in-memory transform chain.
+ */
+module.exports = function comine(...formats) {
+  return format(...formats)();
+};

--- a/format.js
+++ b/format.js
@@ -15,7 +15,7 @@ module.exports = function (formatFn) {
   // Remark: a little awkward that multiple formats is automagically created
   // for you, but it feels correct w.r.t. current API designs.
   const formats = Array.prototype.slice.call(arguments);
-  return createFormat(cascade(formats))();
+  return createFormat(cascade(formats));
 };
 
 /*
@@ -26,13 +26,13 @@ function createFormat(formatFn) {
     throw new Error(`Format functions must be synchronous taking a two arguments: (info, opts)\n${formatFn.toString()}`);
   }
 
-  //
-  // Create a wrapper Prototype of `Format` which
-  // has the `formatFn` set to `_format`.
-  //
-  function FormatWrap(opts) { Format.call(this, opts); }
-  util.inherits(FormatWrap, Format);
-  FormatWrap.prototype.transform = formatFn;
+  /*
+   * function Format (options)
+   * Base prototype which calls a `_format`
+   * function and pushes the result.
+   */
+  function Format(options) { this.options = options || {}; };
+  Format.prototype.transform = formatFn;
 
   //
   // Create a function which returns new instances of
@@ -41,25 +41,16 @@ function createFormat(formatFn) {
   // require('winston').formats.json();
   //
   function createFormatWrap(opts) {
-    return new FormatWrap(opts);
+    return new Format(opts);
   }
 
   //
   // Expose the FormatWrap through the create function
   // for testability.
   //
-  createFormatWrap.Format = FormatWrap;
+  createFormatWrap.Format = Format;
   return createFormatWrap;
 }
-
-/*
- * function Format (options)
- * Base prototype which calls a `_format`
- * function and pushes the result.
- */
-function Format(options) {
-  this.options = options || {};
-};
 
 /*
  * function cascade(formats)

--- a/index.js
+++ b/index.js
@@ -15,59 +15,33 @@ const format = exports.format = require('./format');
  */
 const levels = exports.levels = require('./levels');
 
+/**
+ * @api private
+ * method {function} exposeFormat
+ * Exposes a sub-format on the main format object
+ * as a lazy-loaded getter.
+ */
+function exposeFormat(name, path) {
+  path = path || name;
+  Object.defineProperty(format, name, {
+    get: function () { return require('./' + path); }
+  });
+}
+
 //
 // Setup all transports as lazy-loaded getters.
 //
-Object.defineProperty(format, 'cli', {
-  get: function () {
-    return require('./cli');
-  }
-});
-
-Object.defineProperty(format, 'colorize', {
-  get: function () {
-    return require('./colorize');
-  }
-});
-
-Object.defineProperty(format, 'json', {
-  get: function () {
-    return require('./json');
-  }
-});
-
-Object.defineProperty(format, 'logstash', {
-  get: function () {
-    return require('./logstash');
-  }
-});
-
-Object.defineProperty(format, 'padLevels', {
-  get: function () {
-    return require('./pad-levels');
-  }
-});
-
-Object.defineProperty(format, 'prettyPrint', {
-  get: function () {
-    return require('./pretty-print');
-  }
-});
-
-Object.defineProperty(format, 'simple', {
-  get: function () {
-    return require('./simple');
-  }
-});
-
-Object.defineProperty(format, 'splat', {
-  get: function () {
-    return require('./splat');
-  }
-});
-
-Object.defineProperty(format, 'uncolorize', {
-  get: function () {
-    return require('./uncolorize');
-  }
-});
+exposeFormat('align');
+exposeFormat('cli');
+exposeFormat('combine');
+exposeFormat('colorize');
+exposeFormat('json');
+exposeFormat('label');
+exposeFormat('logstash');
+exposeFormat('padLevels', 'pad-levels');
+exposeFormat('prettyPrint', 'pretty-print');
+exposeFormat('printf');
+exposeFormat('simple');
+exposeFormat('splat');
+exposeFormat('timestamp');
+exposeFormat('uncolorize');

--- a/index.js
+++ b/index.js
@@ -1,10 +1,4 @@
-/*
- * index.js: Set of all known formats.
- *
- * (C) 2010 Charlie Robbins
- * MIT LICENCE
- *
- */
+'use strict';
 
 /**
  * @api public

--- a/json.js
+++ b/json.js
@@ -4,8 +4,9 @@ const format = require('./format');
 
 /*
  * function json (opts)
- * Returns a new instance of the JSON format TransformStream
- * with turns a log `info` object into pure JSON.
+ * Returns a new instance of the JSON format that turns a log `info`
+ * object into pure JSON. This was previously exposed as { json: true }
+ * to transports in `winston < 3.0.0`.
  */
 module.exports = format(function (info, opts) {
   //

--- a/label.js
+++ b/label.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const format = require('./format');
+
+/*
+ * function label (opts)
+ * Returns a new instance of the label Format which adds the specified
+ * `opts.label` before the message. This was previously exposed as
+ * { label: 'my label' } to transports in `winston < 3.0.0`.
+ */
+module.exports = format(function (info, opts) {
+  info.message = '[' opts.label + ']' + info.message;
+  return info;
+});

--- a/label.js
+++ b/label.js
@@ -9,6 +9,11 @@ const format = require('./format');
  * { label: 'my label' } to transports in `winston < 3.0.0`.
  */
 module.exports = format(function (info, opts) {
-  info.message = '[' opts.label + ']' + info.message;
+  if (opts.message) {
+    info.message = '[' + opts.label + ']' + info.message;
+    return info;
+  }
+
+  info.label = opts.label;
   return info;
 });

--- a/levels.js
+++ b/levels.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const Colorizer = require('./colorize').Colorizer;
 
 /*

--- a/logstash.js
+++ b/logstash.js
@@ -4,8 +4,10 @@ const format = require('./format');
 
 /*
  * function logstash (opts)
- * Returns a new instance of the LogStash format TransformStream
- * with turns a log `info` object into pure JSON.
+ * Returns a new instance of the LogStash Format that turns a
+ * log `info` object into pure JSON with the appropriate logstash
+ * options. This was previously exposed as { logstash: true }
+ * to transports in `winston < 3.0.0`.
  */
 module.exports = format(function (info, opts) {
   var logstash = {};

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "logform",
   "version": "1.0.0",
-  "description": "An mutable object format designed for chaining & objectMode streams",
+  "description": "An mutable object-based log format designed for chaining & objectMode streams.",
   "main": "index.js",
   "scripts": {
     "test": "nyc mocha test/*.test.js"
@@ -23,7 +23,8 @@
   },
   "homepage": "https://github.com/winstonjs/logform#readme",
   "dependencies": {
-    "colors": "^1.1.2"
+    "colors": "^1.1.2",
+    "date-fns": "^1.28.5"
   },
   "devDependencies": {
     "assume": "^1.5.1",

--- a/pad-levels.js
+++ b/pad-levels.js
@@ -4,9 +4,9 @@ const format = require('./format');
 
 /*
  * function padLevels (opts)
- * Returns a new instance of the padLevels format TransformStream
- * which pads levels to be the same length. This was previously
- * exposed as the `padLevels` option to transports in `winston < 3.0.0`.
+ * Returns a new instance of the padLevels Format which pads
+ * levels to be the same length. This was previously exposed as
+ * { padLevels: true } to transports in `winston < 3.0.0`.
  */
 module.exports = format(function (info, opts) {
 

--- a/pretty-print.js
+++ b/pretty-print.js
@@ -5,9 +5,9 @@ const format = require('./format');
 
 /*
  * function prettyPrint (opts)
- * Returns a new instance of the prettyPrint format TransformStream
- * with "prettyPrint" serializes `info` objects. This was previously
- * exposed as the `prettyPrint` option to transports in `winston < 3.0.0`.
+ * Returns a new instance of the prettyPrint Format that "prettyPrint"
+ * serializes `info` objects. This was previously exposed as
+ * { prettyPrint: true } to transports in `winston < 3.0.0`.
  */
 module.exports = format(function (info, opts) {
   info.raw = inspect(info, false, opts.depth || null, opts.colorize);

--- a/printf.js
+++ b/printf.js
@@ -1,0 +1,19 @@
+'use strict';
+
+/*
+ * function printf (templateFn)
+ * Returns a new instance of the printf Format that creates an
+ * intermediate prototype to store the
+ * level colors to `info` objects. This was previously exposed
+ * as { colorize: true } to transports in `winston < 3.0.0`.
+ */
+module.exports = function createPrintf(templateFn) {
+  function Printf() {}
+  Printf.prototype.template = templateFn;
+  Printf.prototype.transform = function (info) {
+    info.raw = this.template(info);
+    return info;
+  };
+
+  return new Printf();
+};

--- a/simple.js
+++ b/simple.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const util = require('util');
 const format = require('./format');
 
 /*
@@ -8,9 +7,13 @@ const format = require('./format');
  * Returns a new instance of the simple format TransformStream
  * which writes a simple representation of logs.
  *
- *    ${info.level}: ${info.message} ${JSON.stringify(info)}
+ *    const { level, message, ...rest } = info;
+ *    ${level}: ${message} ${JSON.stringify(rest)}
  */
 module.exports = format(function (info, opts) {
-  info.raw = util.format('%s: %s %j', info.level, info.message, info);
+  info.raw = info.level + ': ' + info.message + JSON.stringify(
+    Object.assign({}, info, { level: undefined, message: undefined })
+  );
+
   return info;
 });

--- a/simple.js
+++ b/simple.js
@@ -11,7 +11,7 @@ const format = require('./format');
  *    ${level}: ${message} ${JSON.stringify(rest)}
  */
 module.exports = format(function (info, opts) {
-  info.raw = info.level + ': ' + info.message + JSON.stringify(
+  info.raw = info.level + ': ' + info.message + ' ' + JSON.stringify(
     Object.assign({}, info, { level: undefined, message: undefined })
   );
 

--- a/splat.js
+++ b/splat.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const format = require('./format');
+const util = require('util');
 
 /*
  * function splat (opts)
@@ -9,5 +10,9 @@ const format = require('./format');
  * previously exposed implicitly in `winston < 3.0.0`.
  */
 module.exports = format(function (info, opts) {
-  throw new Error('Not implemented.');
+  if (info.splat) {
+    info.message = util.format(message, ...info.splat);
+  }
+
+  return info;
 });

--- a/splat.js
+++ b/splat.js
@@ -11,7 +11,7 @@ const util = require('util');
  */
 module.exports = format(function (info, opts) {
   if (info.splat) {
-    info.message = util.format(message, ...info.splat);
+    info.message = util.format(info.message, ...info.splat);
   }
 
   return info;

--- a/test/format.test.js
+++ b/test/format.test.js
@@ -12,14 +12,19 @@ const logform = require('../index');
 describe('{ format }', function () {
   it('has the expected default logform.formats', function () {
     assume(logform.format).is.a('function');
+    assume(logform.format.align).is.a('function');
     assume(logform.format.cli).is.a('function');
     assume(logform.format.colorize).is.a('function');
+    assume(logform.format.combine).is.a('function');
     assume(logform.format.json).is.a('function');
+    assume(logform.format.label).is.a('function');
     assume(logform.format.logstash).is.a('function');
     assume(logform.format.padLevels).is.a('function');
     assume(logform.format.prettyPrint).is.a('function');
+    assume(logform.format.printf).is.a('function');
     assume(logform.format.splat).is.a('function');
     assume(logform.format.simple).is.a('function');
+    assume(logform.format.timestamp).is.a('function');
     assume(logform.format.uncolorize).is.a('function');
   });
 });

--- a/timestamp.js
+++ b/timestamp.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const format = require('./format');
+const formatDate = require('date-fns/format');
+
+/*
+ * function timestamp (opts)
+ * Returns a new instance of the timestamp Format which adds a timestamp
+ * to the info. It was previously available in winston < 3.0.0 as:
+ *
+ * - { timestamp: true }             // `new Date.toISOString()`
+ * - { timestamp: function:String }  // Value returned by `timestamp()`
+ */
+module.exports = format(function (info, opts) {
+  if (opts.format) {
+    info.timestamp = typeof opts.format === 'function'
+      ? opts.format()
+      : formatDate(opts.format);
+  }
+
+  if (!info.timestamp) {
+    info.timestamp = new Date.toISOString();
+  }
+
+  return info;
+});

--- a/uncolorize.js
+++ b/uncolorize.js
@@ -5,9 +5,9 @@ const format = require('./format');
 
 /*
  * function uncolorize (opts)
- * Returns a new instance of the uncolorize format TransformStream
- * which strips colors from `info` objects. This was previously
- * exposed as the `stripColors` option to transports in `winston < 3.0.0`.
+ * Returns a new instance of the uncolorize Format that strips colors
+ * from `info` objects. This was previously exposed as { stripColors: true }
+ * to transports in `winston < 3.0.0`.
  */
 module.exports = format(function (info, opts) {
   info.level = colors.strip(info.level);


### PR DESCRIPTION
> Related to: https://github.com/winstonjs/winston/pull/1083

Not enough test coverage yet, but there is significant coverage in the upstream `winston#3.x` tests. Follow-up PR will address the coverage numbers.