### PR TITLE
Fix broken example code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ const alignedWithColorsAndTime = format.combine(
   format.colorize(),
   format.timestamp(),
   format.align(),
-  format.printf(info => `${info.timestamp} ${info.level}: ${message}`)
+  format.printf(info => `${info.timestamp} ${info.level}: ${info.message}`)
 );
 ```
 


### PR DESCRIPTION
${message} isn't valid syntax. Changed to ${info.message} since it seems that the info object was just forgotten.