### PR TITLE
Fix timestamp and replace date-fns with fecha (with test cases)

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/winstonjs/logform#readme",
   "dependencies": {
     "colors": "^1.1.2",
-    "date-fns": "^1.28.5"
+    "fecha": "^2.3.2"
   },
   "devDependencies": {
     "assume": "^1.5.1",

--- a/test/timestamp.test.js
+++ b/test/timestamp.test.js
@@ -1,0 +1,56 @@
+'use strict';
+
+const assume = require('assume');
+const timestamp = require('../timestamp');
+const helpers = require('./helpers');
+const MESSAGE = Symbol.for('message');
+
+describe('timestamp', function () {
+  it('timestamp() (default) sets info[timestamp]', helpers.assumeFormatted(
+    timestamp(),
+    { level: 'info', message: 'whatever', timestamp: new Date().toISOString() },
+    function (info, expected) {
+      assume(info.level).is.a('string');
+      assume(info.message).is.a('string');
+      assume(info.level).equals('info');
+      assume(info.message).equals('whatever');
+      assume(info.timestamp).is.a('string');
+    }
+  ));
+
+  it('timestamp({ format: function () { return \'test timestamp\'; } }) sets info[timestamp]', helpers.assumeFormatted(
+    timestamp({
+      format: function () {
+        return 'test timestamp';
+      }
+    }),
+    { level: 'info', message: 'whatever', timestamp: 'test timestamp' },
+    function (info, expected) {
+      assume(info.level).is.a('string');
+      assume(info.message).is.a('string');
+      assume(info.level).equals('info');
+      assume(info.message).equals('whatever');
+      assume(info.timestamp).is.a('string');
+      assume(info.timestamp).equals('test timestamp');
+
+      const raw = JSON.stringify(expected);
+      assume(JSON.stringify(info)).equals(raw);
+    }
+  ));
+
+  it('timestamp({ format: \'YYYY-MM-DD\' }) sets info[timestamp]', helpers.assumeFormatted(
+    timestamp({
+      format: 'YYYY-MM-DD'
+    }),
+    { level: 'info', message: 'whatever', timestamp: new Date().toISOString() },
+    function (info, expected) {
+      assume(info.level).is.a('string');
+      assume(info.message).is.a('string');
+      assume(info.level).equals('info');
+      assume(info.message).equals('whatever');
+      assume(info.timestamp).is.a('string');
+    }
+  ));
+
+  it('exposes the Format prototype', helpers.assumeHasPrototype(timestamp));
+});

--- a/timestamp.js
+++ b/timestamp.js
@@ -1,7 +1,7 @@
 'use strict';
 
+const fecha = require('fecha');
 const format = require('./format');
-const formatDate = require('date-fns/format');
 
 /*
  * function timestamp (info)
@@ -15,7 +15,7 @@ module.exports = format(function (info, opts) {
   if (opts.format) {
     info.timestamp = typeof opts.format === 'function'
       ? opts.format()
-      : formatDate(new Date(), opts.format);
+      : fecha.format(new Date(), opts.format);
   }
 
   if (!info.timestamp) {

--- a/timestamp.js
+++ b/timestamp.js
@@ -15,7 +15,7 @@ module.exports = format(function (info, opts) {
   if (opts.format) {
     info.timestamp = typeof opts.format === 'function'
       ? opts.format()
-      : formatDate(opts.format);
+      : formatDate(new Date(), opts.format);
   }
 
   if (!info.timestamp) {


### PR DESCRIPTION
This PR solves the same issue as #6 (#4), but it also:
 - Adds test cases `./test/timestamp.test.js`
 - Replaces `date-fns` with [`fecha`](https://github.com/taylorhakes/fecha) to reduce install size, about ~3.8 MB (see pictures)

**`date-fns`:**
![alt text](https://i.imgur.com/RHle3v4.png "date-fns size")

**`fecha`:**
![alt text](https://i.imgur.com/d1VAdb7.png "fecha size")
