### PR TITLE
Remove unnecessary message

### DIFF
--- a/simple.js
+++ b/simple.js
@@ -9,17 +9,23 @@ const MESSAGE = Symbol.for('message');
  * Returns a new instance of the simple format TransformStream
  * which writes a simple representation of logs.
  *
- *    const { level, message, ...rest } = info;
- *    ${level}: ${message} ${JSON.stringify(rest)}
+ *    const { level, message, splat, ...rest } = info;
+ *
+ *    ${level}: ${message}                            if rest is empty
+ *    ${level}: ${message} ${JSON.stringify(rest)}    otherwise
  */
 module.exports = format(function (info) {
-  info[MESSAGE] = info.level + ': ' + info.message + ' ' + JSON.stringify(
-    Object.assign({}, info, {
-      level: undefined,
-      message: undefined,
-      splat: undefined
-    })
-  );
+  const stringifiedRest = JSON.stringify(Object.assign({}, info, {
+    level: undefined,
+    message: undefined,
+    splat: undefined
+  }));
+
+  if (stringifiedRest !== '{}') {
+    info[MESSAGE] = `${info.level}: ${info.message} ${stringifiedRest}`;
+  } else {
+    info[MESSAGE] = `${info.level}: ${info.message}`;
+  }
 
   return info;
 });

--- a/test/simple.test.js
+++ b/test/simple.test.js
@@ -16,7 +16,7 @@ describe('simple', function () {
       assume(info.level).equals('info');
       assume(info.message).equals('whatever');
 
-      assume(info[MESSAGE]).equals('info: whatever {}');
+      assume(info[MESSAGE]).equals('info: whatever');
     }
   ));
 
@@ -31,7 +31,22 @@ describe('simple', function () {
       assume(info.message).equals('whatever');
       assume(info.splat).deep.equals([1, 2, 3]);
 
-      assume(info[MESSAGE]).equals('info: whatever {}');
+      assume(info[MESSAGE]).equals('info: whatever');
+    }
+  ));
+
+  it('simple() shows { rest }', helpers.assumeFormatted(
+    simple(),
+    { level: 'info', message: 'whatever', rest: 'something' },
+    function (info, expected) {
+      assume(info.level).is.a('string');
+      assume(info.message).is.a('string');
+      assume(info.rest).is.an('string');
+      assume(info.level).equals('info');
+      assume(info.message).equals('whatever');
+      assume(info.rest).equals('something');
+
+      assume(info[MESSAGE]).equals('info: whatever {"rest":"something"}');
     }
   ));
 });

--- a/test/uncolorize.test.js
+++ b/test/uncolorize.test.js
@@ -57,7 +57,7 @@ describe('uncolorize', function () {
       assume(info.message).equals(colors.strip(colored.message));
       assume(info.message).not.equals(colored.message);
 
-      assume(info[MESSAGE]).equals('info: whatever {}');
+      assume(info[MESSAGE]).equals('info: whatever');
       assume(info[MESSAGE]).equals(colors.strip(colored[MESSAGE]));
       assume(info[MESSAGE]).not.equals(colored[MESSAGE]);
     }
@@ -72,7 +72,7 @@ describe('uncolorize', function () {
 
       assume(info.level).equals(colors.green('info'));
       assume(info.message).equals('whatever');
-      assume(info[MESSAGE]).equals('info: whatever {}');
+      assume(info[MESSAGE]).equals('info: whatever');
     }
   ));
 
@@ -85,7 +85,7 @@ describe('uncolorize', function () {
 
       assume(info.level).equals('info');
       assume(info.message).equals(colors.green('whatever'));
-      assume(info[MESSAGE]).equals('info: whatever {}');
+      assume(info[MESSAGE]).equals('info: whatever');
     }
   ));
 
@@ -111,7 +111,7 @@ describe('uncolorize', function () {
 
       assume(info.level).equals(colors.green('info'));
       assume(info.message).equals(colors.green('whatever'));
-      assume(info[MESSAGE]).equals('info: whatever {}');
+      assume(info[MESSAGE]).equals('info: whatever');
     }
   ));
 });


### PR DESCRIPTION
This PR aims to improving logging using simple format. As a default behavior, logs look like:
```text
info: whatever {}
```
where `{}` shows that there is no other information to display. In such a case, logs should look like:
```text
info: whatever
```

On the other hand, custom info must be printed if exists:
```text
info: whatever {"rest":"something"}
```