### PR TITLE
Fix compilation on Babel 6

### DIFF
--- a/combine.js
+++ b/combine.js
@@ -10,9 +10,9 @@ const format = require('./format');
  * an in-memory transform chain.
  */
 module.exports = function combined(...formats) {
-  const combined = format(cascade(formats));
-  const instance = combined();
-  instance.Format = combined.Format;
+  const createCombined = format(cascade(formats));
+  const instance = createCombined();
+  instance.Format = createCombined.Format;
   return instance;
 };
 


### PR DESCRIPTION
On Babel 6, function locals cannot have the same name as the function.
See the following issue - it is fixed in Babel 7, but not in 6.

https://github.com/babel/babel/issues/5491
