### PR TITLE
Add ms format to support '+N ms' format.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -41,6 +41,7 @@ export namespace format {
   function json(opts?: object): Format;
   function label(opts?: object): Format;
   function logstash(opts?: object): Format;
+  function ms(opts?: object): Format;
   function padLevels(opts?: object): Format;
   function prettyPrint(opts?: object): Format;
   function printf(templateFunction: (info: TransformableInfo) => string): Format;

--- a/index.js
+++ b/index.js
@@ -40,6 +40,7 @@ exposeFormat('json');
 exposeFormat('label');
 exposeFormat('logstash');
 exposeFormat('metadata');
+exposeFormat('ms');
 exposeFormat('padLevels', 'pad-levels');
 exposeFormat('prettyPrint', 'pretty-print');
 exposeFormat('printf');

--- a/ms.js
+++ b/ms.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const format = require('./format');
+const ms = require('ms');
+
+/*
+ * function ms (info)
+ * Returns an `info` with a `ms` property. The `ms` property holds the Value
+ * of the time difference between two calls in milliseconds.
+ */
+module.exports = format(function (info) {
+  const curr = +new Date();
+  this.diff = curr - (this.prevTime || curr);
+  this.prevTime = curr;
+  info.ms = '+' + ms(this.diff);
+
+  return info;
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -405,6 +405,14 @@
       "dev": true,
       "requires": {
         "ms": "2.0.0"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
       }
     },
     "decamelize": {
@@ -1342,6 +1350,14 @@
           "dev": true,
           "requires": {
             "ms": "2.0.0"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+              "dev": true
+            }
           }
         },
         "glob": {
@@ -1376,10 +1392,9 @@
       }
     },
     "ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
     },
     "mute-stream": {
       "version": "0.0.7",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   "homepage": "https://github.com/winstonjs/logform#readme",
   "dependencies": {
     "colors": "^1.2.0",
-    "fecha": "^2.3.2"
+    "fecha": "^2.3.2",
+    "ms": "^2.1.1"
   },
   "devDependencies": {
     "assume": "^2.0.0",

--- a/test/ms.test.js
+++ b/test/ms.test.js
@@ -1,0 +1,22 @@
+/* eslint no-unused-vars: 0 */
+'use strict';
+
+const assume = require('assume');
+const helpers = require('./helpers');
+const ms = require('../ms');
+const MESSAGE = Symbol.for('message');
+
+describe('ms', function () {
+  it('ms() set the ms to info.ms', helpers.assumeFormatted(
+    ms(),
+    { level: 'info', message: 'time all the things' },
+    function (info, expected) {
+      assume(info.level).is.a('string');
+      assume(info.message).is.a('string');
+      assume(info.ms).is.a('string');
+      assume(info.level).equals('info');
+      assume(info.message).equals('time all the things');
+      assume(info[MESSAGE]).equals(undefined);
+    }
+  ));
+});


### PR DESCRIPTION
This should fix #20, it adds a `ms` property to the `info` object. The value of the `ms` property is the difference between two calls of the function. To implement this feature I looked how it was done by the `debug` module also mentioned in #20, so this PR also adds a new dependency on [`ms`](https://www.npmjs.com/package/ms). Tests are also added for this PR in `test/ms.test.js`.

I also updated the `index.d.js` file for the TypeScript definitions. I've never worked with TypeScript so I hope it is correct.