### PR TITLE
Fix Webpack warnings

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ exports.levels = require('./levels');
 function exposeFormat(name, path) {
   path = path || name;
   Object.defineProperty(format, name, {
-    get: function () { return require('./' + path); },
+    get: function () { return require('./' + path + '.js'); },
     configurable: true
   });
 }


### PR DESCRIPTION
A small change which addresses warnings generated by Webpack.

When Webpack encounters the require expression in the exposeFormat function (in index.js)

```javascript
require('./' + name)
```

it includes all of the files in the directory, and attempts to transpile each. This generates warnings because the `LICENSE`, `README.md`, etc files obviously weren't meant to be transpiled.  This [SO post](https://stackoverflow.com/questions/49961203/how-to-get-rid-of-webpack-warnings-when-including-the-winston-logger-using-conte) explains in more detail.

A nice solution is to give Webpack a hint about what to include by changing the require expression to:

```javascript
require('./' + name + '.js')
```

