### PR TITLE
 [feat] Implement padLevels format

### DIFF
--- a/examples/padLevels.js
+++ b/examples/padLevels.js
@@ -1,0 +1,39 @@
+const { format } = require('../');
+const { combine, padLevels, simple } = format;
+
+const MESSAGE = Symbol.for('message');
+
+const paddedFormat = combine(
+  padLevels({
+    // Uncomment for a custom filler for the padding, defaults to ' '.
+    // filler: 'foo',
+    // Levels has to be defined, same as `winston.createLoggers({ levels })`.
+    levels: {
+      error: 0,
+      warn: 1,
+      info: 2,
+      http: 3,
+      verbose: 4,
+      debug: 5,
+      silly: 6
+    }
+  }),
+  simple()
+);
+
+const info = paddedFormat.transform({
+  level: 'info',
+  message: 'This is an info level message.'
+});
+const error = paddedFormat.transform({
+  level: 'error',
+  message: 'This is an error level message.'
+});
+const verbose = paddedFormat.transform({
+  level: 'verbose',
+  message: 'This is a verbose level message.'
+});
+
+console.dir(info[MESSAGE]);
+console.dir(error[MESSAGE]);
+console.dir(verbose[MESSAGE]);

--- a/pad-levels.js
+++ b/pad-levels.js
@@ -8,6 +8,7 @@ const format = require('./format');
  * Returns a new instance of the padLevels Format which pads
  * levels to be the same length. This was previously exposed as
  * { padLevels: true } to transports in `winston < 3.0.0`.
+ * TODO: Make `opts.levels` default to `winston.config.npm`.
  */
 module.exports = format(function (info, { levels, filler = ' ' }) {
   const lvls = Object.keys(levels).map(level => level.length);

--- a/pad-levels.js
+++ b/pad-levels.js
@@ -9,6 +9,14 @@ const format = require('./format');
  * levels to be the same length. This was previously exposed as
  * { padLevels: true } to transports in `winston < 3.0.0`.
  */
-module.exports = format(function (info, opts) {
+module.exports = format(function (info, { levels, filler = ' ' }) {
+  const lvls = Object.keys(levels).map(level => level.length);
+  const longest = Math.max(...lvls);
+  const targetLength = Math.floor(longest + 1) - info.level.length;
+  let padStr = String(filler);
+  padStr += padStr.repeat(targetLength / padStr.length);
 
+  info.padding = padStr.slice(0, targetLength);
+
+  return info;
 });

--- a/pad-levels.js
+++ b/pad-levels.js
@@ -1,7 +1,47 @@
 /* eslint no-unused-vars: 0 */
 'use strict';
 
-const format = require('./format');
+class Padder {
+  constructor(opts = {}) {
+    if (opts.levels) {
+      this.addPadding(opts.levels, opts.filler);
+    }
+
+    this.options = opts;
+  }
+
+  static getLongestLevel(levels) {
+    const lvls = Object.keys(levels).map(level => level.length);
+    return Math.max(...lvls);
+  }
+
+  static calcPadding(level, filler) {
+    const targetLen = Padder.longestLevel + 1 - level.length;
+    const rep = Math.floor(targetLen / filler.length);
+    const padStr = `${filler}${filler.repeat(rep)}`;
+
+    return padStr.slice(0, targetLen);
+  }
+
+  static addPadding(levels, filler = ' ') {
+    Padder.longestLevel = Padder.getLongestLevel(levels);
+    Padder.allPadding = Object.keys(levels).reduce((acc, level) => {
+      acc[level] = Padder.calcPadding(level, filler);
+      return acc;
+    }, {});
+
+    return Padder.allPadding;
+  }
+
+  addPadding(levels, filler) {
+    return Padder.addPadding(levels, filler);
+  }
+
+  transform(info, opts) {
+    info.padding = this.addPadding(opts.levels, opts.filler);
+    return info;
+  }
+}
 
 /*
  * function padLevels (info)
@@ -10,14 +50,10 @@ const format = require('./format');
  * { padLevels: true } to transports in `winston < 3.0.0`.
  * TODO: Make `opts.levels` default to `winston.config.npm`.
  */
-module.exports = format(function (info, { levels, filler = ' ' }) {
-  const lvls = Object.keys(levels).map(level => level.length);
-  const longest = Math.max(...lvls);
-  const targetLength = Math.floor(longest + 1) - info.level.length;
-  let padStr = String(filler);
-  padStr += padStr.repeat(targetLength / padStr.length);
+module.exports = function (opts) {
+  return new Padder(opts);
+};
 
-  info.padding = padStr.slice(0, targetLength);
-
-  return info;
-});
+module.exports.Padder
+  = module.exports.Format
+  = Padder;

--- a/simple.js
+++ b/simple.js
@@ -21,11 +21,11 @@ module.exports = format(function (info) {
     splat: undefined
   }));
 
-  info.padding = info.padding || '';
+  const padding = info.padding && info.padding[info.level] || '';
   if (stringifiedRest !== '{}') {
-    info[MESSAGE] = `${info.level}:${info.padding} ${info.message} ${stringifiedRest}`;
+    info[MESSAGE] = `${info.level}:${padding} ${info.message} ${stringifiedRest}`;
   } else {
-    info[MESSAGE] = `${info.level}:${info.padding} ${info.message}`;
+    info[MESSAGE] = `${info.level}:${padding} ${info.message}`;
   }
 
   return info;

--- a/simple.js
+++ b/simple.js
@@ -21,10 +21,11 @@ module.exports = format(function (info) {
     splat: undefined
   }));
 
+  info.padding = info.padding || '';
   if (stringifiedRest !== '{}') {
-    info[MESSAGE] = `${info.level}: ${info.message} ${stringifiedRest}`;
+    info[MESSAGE] = `${info.level}:${info.padding} ${info.message} ${stringifiedRest}`;
   } else {
-    info[MESSAGE] = `${info.level}: ${info.message}`;
+    info[MESSAGE] = `${info.level}:${info.padding} ${info.message}`;
   }
 
   return info;

--- a/test/pad-levels.test.js
+++ b/test/pad-levels.test.js
@@ -1,0 +1,52 @@
+/* eslint no-unused-vars: 0 */
+'use strict';
+
+const assume = require('assume');
+const helpers = require('./helpers');
+const padLevels = require('../pad-levels');
+const MESSAGE = Symbol.for('message');
+
+describe('ms', function () {
+  it('padLevels({ levels }) set the padding to info.padding', helpers.assumeFormatted(
+    padLevels({
+      levels: {
+        foo: 0,
+        bar: 1,
+        baz: 2,
+        foobar: 3
+      }
+    }),
+    { level: 'info', message: 'pad all the things' },
+    function (info, expected) {
+      assume(info.level).is.a('string');
+      assume(info.message).is.a('string');
+      assume(info.padding).is.a('string');
+      assume(info.level).equals('info');
+      assume(info.padding).equals('   ');
+      assume(info.message).equals('pad all the things');
+      assume(info[MESSAGE]).equals(undefined);
+    }
+  ));
+
+  it('padLevels({ levels, filler }) set the padding to info.padding with a custom filler', helpers.assumeFormatted(
+    padLevels({
+      levels: {
+        foo: 0,
+        bar: 1,
+        baz: 2,
+        foobar: 3
+      },
+      filler: 'foo'
+    }),
+    { level: 'info', message: 'pad all the things' },
+    function (info, expected) {
+      assume(info.level).is.a('string');
+      assume(info.message).is.a('string');
+      assume(info.padding).is.a('string');
+      assume(info.level).equals('info');
+      assume(info.padding).equals('foo');
+      assume(info.message).equals('pad all the things');
+      assume(info[MESSAGE]).equals(undefined);
+    }
+  ));
+});

--- a/test/pad-levels.test.js
+++ b/test/pad-levels.test.js
@@ -5,48 +5,103 @@ const assume = require('assume');
 const helpers = require('./helpers');
 const padLevels = require('../pad-levels');
 const MESSAGE = Symbol.for('message');
+const fixtures = require('./fixtures');
+const Padder = padLevels.Padder;
 
-describe('ms', function () {
+describe('padLevels', function () {
   it('padLevels({ levels }) set the padding to info.padding', helpers.assumeFormatted(
-    padLevels({
-      levels: {
-        foo: 0,
-        bar: 1,
-        baz: 2,
-        foobar: 3
-      }
-    }),
+    padLevels({ levels: fixtures.npm.levels }),
     { level: 'info', message: 'pad all the things' },
     function (info, expected) {
       assume(info.level).is.a('string');
       assume(info.message).is.a('string');
-      assume(info.padding).is.a('string');
+      assume(info.padding).is.an('object');
       assume(info.level).equals('info');
-      assume(info.padding).equals('   ');
+      assume(info.padding[info.level]).equals('    ');
       assume(info.message).equals('pad all the things');
       assume(info[MESSAGE]).equals(undefined);
     }
   ));
 
   it('padLevels({ levels, filler }) set the padding to info.padding with a custom filler', helpers.assumeFormatted(
-    padLevels({
-      levels: {
-        foo: 0,
-        bar: 1,
-        baz: 2,
-        foobar: 3
-      },
-      filler: 'foo'
-    }),
+    padLevels({ levels: fixtures.npm.levels, filler: 'foo' }),
     { level: 'info', message: 'pad all the things' },
     function (info, expected) {
       assume(info.level).is.a('string');
       assume(info.message).is.a('string');
-      assume(info.padding).is.a('string');
+      assume(info.padding).is.an('object');
       assume(info.level).equals('info');
-      assume(info.padding).equals('foo');
+      assume(info.padding[info.level]).equals('foof');
       assume(info.message).equals('pad all the things');
       assume(info[MESSAGE]).equals(undefined);
     }
   ));
+});
+
+it('exposes the Format prototype', helpers.assumeHasPrototype(padLevels));
+
+describe('Colorizer', function () {
+  const expected = Object.keys(Object.assign({},
+    fixtures.cli.levels,
+    fixtures.npm.levels,
+    fixtures.syslog.levels
+  ));
+
+  it('Padder.addColors({ string: number })', function () {
+    Padder.addPadding(Object.assign({},
+      fixtures.cli.levels,
+      fixtures.npm.levels,
+      fixtures.syslog.levels
+    ));
+
+    const keys = Object.keys(Padder.allPadding);
+    assume(keys).deep.equals(expected);
+
+    const padding = Padder.allPadding[keys.pop()];
+    assume(padding).to.be.a('string');
+    assume(padding[0]).to.equal(' ');
+  });
+
+  it('Padder.addColors({ string: number }, string)', function () {
+    Padder.addPadding(Object.assign({},
+      fixtures.cli.levels,
+      fixtures.npm.levels,
+      fixtures.syslog.levels
+    ), 'foo');
+
+    const keys = Object.keys(Padder.allPadding);
+    assume(keys).deep.equals(expected);
+
+    const padding = Padder.allPadding[keys.pop()];
+    assume(padding).to.be.a('string');
+    assume(padding[0]).to.equal('f');
+  });
+
+  describe('#padder(levels, filler)', function () {
+    const instance = new Padder();
+
+    it('padd(levels) [all levels]', function () {
+      assume(instance.addPadding(fixtures.npm.levels)).deep.equals({
+        error: '   ',
+        warn: '    ',
+        info: '    ',
+        http: '    ',
+        verbose: ' ',
+        debug: '   ',
+        silly: '   '
+      });
+    });
+
+    it('padder(levels, filler) [all levels]', function () {
+      assume(instance.addPadding(fixtures.npm.levels, 'foo')).deep.equals({
+        error: 'foo',
+        warn: 'foof',
+        info: 'foof',
+        http: 'foof',
+        verbose: 'f',
+        debug: 'foo',
+        silly: 'foo'
+      });
+    });
+  });
 });


### PR DESCRIPTION
This PR implements the `padLevels` format. An example on how to use this format is in the `examples/` folder and the `simple` format was updated to work with he `padLevels` format. And of course tests :+1: .
