### PR TITLE
[refactor] Use more es6-features across the board

### DIFF
--- a/align.js
+++ b/align.js
@@ -8,7 +8,7 @@ const format = require('./format');
  * delimiter before the message to properly align it in the same place.
  * It was previously { align: true } in winston < 3.0.0
  */
-module.exports = format(function (info) {
-  info.message = '\t' + info.message;
+module.exports = format(info => {
+  info.message = `\t${info.message}`;
   return info;
 });

--- a/browser.js
+++ b/browser.js
@@ -15,22 +15,36 @@ const format = exports.format = require('././format');
  */
 exports.levels = require('././levels');
 
+/*
+ * @api private
+ * method {function} exposeFormat
+ * Exposes a sub-format on the main format object
+ * as a lazy-loaded getter.
+ */
+function exposeFormat(name, path) {
+  path = path || name;
+  Object.defineProperty(format, name, {
+    value: require(`./${path}.js`)
+  });
+}
+
 //
 // Setup all transports as eager-loaded exports
 // so that they are static for the bundlers.
 //
-Object.defineProperty(format, 'align',       { value: require('./align') });
-Object.defineProperty(format, 'cli',         { value: require('./cli') });
-Object.defineProperty(format, 'combine',     { value: require('./combine') });
-Object.defineProperty(format, 'colorize',    { value: require('./colorize') });
-Object.defineProperty(format, 'json',        { value: require('./json') });
-Object.defineProperty(format, 'label',       { value: require('./label') });
-Object.defineProperty(format, 'logstash',    { value: require('./logstash') });
-Object.defineProperty(format, 'metadata',    { value: require('./metadata') });
-Object.defineProperty(format, 'padLevels',   { value: require('./pad-levels') });
-Object.defineProperty(format, 'prettyPrint', { value: require('./pretty-print') });
-Object.defineProperty(format, 'printf',      { value: require('./printf') });
-Object.defineProperty(format, 'simple',      { value: require('./simple') });
-Object.defineProperty(format, 'splat',       { value: require('./splat') });
-Object.defineProperty(format, 'timestamp',   { value: require('./timestamp') });
-Object.defineProperty(format, 'uncolorize',  { value: require('./uncolorize') });
+exposeFormat('align');
+exposeFormat('cli');
+exposeFormat('combine');
+exposeFormat('colorize');
+exposeFormat('json');
+exposeFormat('label');
+exposeFormat('logstash');
+exposeFormat('metadata');
+exposeFormat('ms');
+exposeFormat('padLevels', 'pad-levels');
+exposeFormat('prettyPrint', 'pretty-print');
+exposeFormat('printf');
+exposeFormat('simple');
+exposeFormat('splat');
+exposeFormat('timestamp');
+exposeFormat('uncolorize');

--- a/colorize.js
+++ b/colorize.js
@@ -76,7 +76,7 @@ class Colorizer {
     // If it is an Array then iterate over that Array, applying
     // the colors function for each item.
     //
-    for (var i = 0, len = Colorizer.allColors[level].length; i < len; i++) {
+    for (let i = 0, len = Colorizer.allColors[level].length; i < len; i++) {
       message = colors[Colorizer.allColors[level][i]](message);
     }
 
@@ -89,8 +89,7 @@ class Colorizer {
    * `logform` info object.
    */
   transform(info, opts) {
-    var level = info.level;
-
+    const { level } = info;
     if (opts.level || opts.all || !opts.message) {
       info.level = this.colorize(level);
     }
@@ -109,9 +108,7 @@ class Colorizer {
  * level colors to `info` objects. This was previously exposed
  * as { colorize: true } to transports in `winston < 3.0.0`.
  */
-module.exports = function createColorize(opts) {
-  return new Colorizer(opts);
-};
+module.exports = opts => new Colorizer(opts);
 
 //
 // Attach the Colorizer for registration purposes

--- a/combine.js
+++ b/combine.js
@@ -3,20 +3,6 @@
 const format = require('./format');
 
 /*
- * function combine (info)
- * Returns a new instance of the combine Format which combines the specified
- * formats into a new format. This is similar to a pipe-chain in transform streams.
- * We choose to combine the prototypes this way because there is no back pressure in
- * an in-memory transform chain.
- */
-module.exports = function combined(...formats) {
-  const combinedFormat = format(cascade(formats));
-  const instance = combinedFormat();
-  instance.Format = combinedFormat.Format;
-  return instance;
-};
-
-/*
  * function cascade(formats)
  * Returns a function that invokes the `._format` function in-order
  * for the specified set of `formats`. In this manner we say that Formats
@@ -28,9 +14,9 @@ function cascade(formats) {
     return;
   }
 
-  return function cascaded(info) {
+  return info => {
     let obj = info;
-    for (var i = 0; i < formats.length; i++) {
+    for (let i = 0; i < formats.length; i++) {
       obj = formats[i].transform(obj, formats[i].options);
       if (!obj) {
         return false;
@@ -47,8 +33,8 @@ function cascade(formats) {
  * If the format does not define a `transform` function throw an error
  * with more detailed usage.
  */
-function isValidFormat(format) {
-  if (typeof format.transform !== 'function') {
+function isValidFormat(fmt) {
+  if (typeof fmt.transform !== 'function') {
     throw new Error([
       'No transform function found on format. Did you create a format instance?',
       'const myFormat = format(formatFn);',
@@ -58,3 +44,17 @@ function isValidFormat(format) {
 
   return true;
 }
+
+/*
+ * function combine (info)
+ * Returns a new instance of the combine Format which combines the specified
+ * formats into a new format. This is similar to a pipe-chain in transform streams.
+ * We choose to combine the prototypes this way because there is no back pressure in
+ * an in-memory transform chain.
+ */
+module.exports = (...formats) => {
+  const combinedFormat = format(cascade(formats));
+  const instance = combinedFormat();
+  instance.Format = combinedFormat.Format;
+  return instance;
+};

--- a/format.js
+++ b/format.js
@@ -17,7 +17,7 @@ Found: ${formatFn.toString().split('\n')[0]}\n`);
  * function format (formatFn)
  * Returns a create function for the `formatFn`.
  */
-module.exports = function (formatFn) {
+module.exports = formatFn => {
   if (formatFn.length > 2) {
     throw new InvalidFormatError(formatFn);
   }
@@ -27,7 +27,9 @@ module.exports = function (formatFn) {
    * Base prototype which calls a `_format`
    * function and pushes the result.
    */
-  function Format(options) { this.options = options || {}; }
+  function Format(options = {}) {
+    this.options = options;
+  }
   Format.prototype.transform = formatFn;
 
   //

--- a/index.js
+++ b/index.js
@@ -24,7 +24,9 @@ exports.levels = require('./levels');
 function exposeFormat(name, path) {
   path = path || name;
   Object.defineProperty(format, name, {
-    get: function () { return require('./' + path + '.js'); },
+    get() {
+      return require(`./${path}.js`);
+    },
     configurable: true
   });
 }

--- a/json.js
+++ b/json.js
@@ -4,17 +4,6 @@ const format = require('./format');
 const { MESSAGE } = require('triple-beam');
 
 /*
- * function json (info)
- * Returns a new instance of the JSON format that turns a log `info`
- * object into pure JSON. This was previously exposed as { json: true }
- * to transports in `winston < 3.0.0`.
- */
-module.exports = format(function (info, opts) {
-  info[MESSAGE] = JSON.stringify(info, opts.replacer || replacer, opts.space);
-  return info;
-});
-
-/*
  * function replacer (key, value)
  * Handles proper stringification of Buffer output.
  */
@@ -23,3 +12,14 @@ function replacer(key, value) {
     ? value.toString('base64')
     : value;
 }
+
+/*
+ * function json (info)
+ * Returns a new instance of the JSON format that turns a log `info`
+ * object into pure JSON. This was previously exposed as { json: true }
+ * to transports in `winston < 3.0.0`.
+ */
+module.exports = format((info, opts = { replacer, space: 0 }) => {
+  info[MESSAGE] = JSON.stringify(info, opts.replacer, opts.space);
+  return info;
+});

--- a/label.js
+++ b/label.js
@@ -8,9 +8,9 @@ const format = require('./format');
  * `opts.label` before the message. This was previously exposed as
  * { label: 'my label' } to transports in `winston < 3.0.0`.
  */
-module.exports = format(function (info, opts) {
+module.exports = format((info, opts) => {
   if (opts.message) {
-    info.message = '[' + opts.label + '] ' + info.message;
+    info.message = `[${opts.label}] ${info.message}`;
     return info;
   }
 

--- a/levels.js
+++ b/levels.js
@@ -1,12 +1,12 @@
 'use strict';
 
-const Colorizer = require('./colorize').Colorizer;
+const { Colorizer } = require('./colorize');
 
 /*
  * Simple method to register colors with a simpler require
  * path within the module.
  */
-module.exports = function (config) {
+module.exports = config => {
   Colorizer.addColors(config.colors || config);
   return config;
 };

--- a/logstash.js
+++ b/logstash.js
@@ -10,7 +10,7 @@ const { MESSAGE } = require('triple-beam');
  * options. This was previously exposed as { logstash: true }
  * to transports in `winston < 3.0.0`.
  */
-module.exports = format(function (info) {
+module.exports = format(info => {
   const logstash = {};
   if (info.message) {
     logstash['@message'] = info.message;

--- a/metadata.js
+++ b/metadata.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const format = require('./format');
 
 const fillExcept = (info, fillExceptKeys, metadataKey) => {
@@ -30,14 +32,13 @@ const fillWith = (info, fillWithKeys, metadataKey) => {
  * Adds in a "metadata" object to collect extraneous data, similar to the metadata
  * object in winston 2.x.
  */
-module.exports = format(function (info, opts = {}) {
+module.exports = format((info, opts = {}) => {
   let metadataKey = 'metadata';
-  let fillExceptKeys = [];
-
   if (opts.key) {
     metadataKey = opts.key;
   }
 
+  let fillExceptKeys = [];
   if (!opts.fillExcept && !opts.fillWith) {
     fillExceptKeys.push('level');
     fillExceptKeys.push('message');

--- a/metadata.js
+++ b/metadata.js
@@ -2,31 +2,32 @@
 
 const format = require('./format');
 
-const fillExcept = (info, fillExceptKeys, metadataKey) => {
-  const savedKeys = {};
-  const metadata = {};
+function fillExcept(info, fillExceptKeys, metadataKey) {
+  const savedKeys = fillExceptKeys.reduce((acc, key) => {
+    acc[key] = info[key];
+    delete info[key];
+    return acc;
+  }, {});
+  const metadata = Object.keys(info).reduce((acc, key) => {
+    acc[key] = info[key];
+    delete info[key];
+    return acc;
+  }, {});
 
-  fillExceptKeys.forEach((key) => {
-    savedKeys[key] = info[key];
-    delete info[key];
+  Object.assign(info, savedKeys, {
+    [metadataKey]: metadata
   });
-  Object.keys(info).forEach((key) => {
-    metadata[key] = info[key];
-    delete info[key];
-  });
-  Object.assign(info, savedKeys, { [metadataKey]: metadata });
   return info;
-};
+}
 
-const fillWith = (info, fillWithKeys, metadataKey) => {
-  const metadata = {};
-  fillWithKeys.forEach((key) => {
-    metadata[key] = info[key];
+function fillWith(info, fillWithKeys, metadataKey) {
+  info[metadataKey] = fillWithKeys.reduce((acc, key) => {
+    acc[key] = info[key];
     delete info[key];
-  });
-  info[metadataKey] = metadata;
+    return acc;
+  }, {});
   return info;
-};
+}
 
 /**
  * Adds in a "metadata" object to collect extraneous data, similar to the metadata

--- a/ms.js
+++ b/ms.js
@@ -8,11 +8,11 @@ const ms = require('ms');
  * Returns an `info` with a `ms` property. The `ms` property holds the Value
  * of the time difference between two calls in milliseconds.
  */
-module.exports = format(function (info) {
+module.exports = format(info => {
   const curr = +new Date();
   this.diff = curr - (this.prevTime || curr);
   this.prevTime = curr;
-  info.ms = '+' + ms(this.diff);
+  info.ms = `+${ms(this.diff)}`;
 
   return info;
 });

--- a/pad-levels.js
+++ b/pad-levels.js
@@ -5,10 +5,7 @@ const { configs } = require('triple-beam');
 
 class Padder {
   constructor(opts = { levels: configs.npm.levels }) {
-    if (opts.levels) {
-      this.addPadding(opts.levels, opts.filler);
-    }
-
+    this.addPadding(opts.levels, opts.filler);
     this.options = opts;
   }
 
@@ -51,9 +48,7 @@ class Padder {
  * levels to be the same length. This was previously exposed as
  * { padLevels: true } to transports in `winston < 3.0.0`.
  */
-module.exports = function (opts) {
-  return new Padder(opts);
-};
+module.exports = opts => new Padder(opts);
 
 module.exports.Padder
   = module.exports.Format

--- a/pretty-print.js
+++ b/pretty-print.js
@@ -10,7 +10,7 @@ const { MESSAGE } = require('triple-beam');
  * serializes `info` objects. This was previously exposed as
  * { prettyPrint: true } to transports in `winston < 3.0.0`.
  */
-module.exports = format(function (info, opts) {
-  info[MESSAGE] = inspect(info, false, opts.depth || null, opts.colorize);
+module.exports = format((info, opts = { depth: null }) => {
+  info[MESSAGE] = inspect(info, false, opts.depth, opts.colorize);
   return info;
 });

--- a/printf.js
+++ b/printf.js
@@ -2,21 +2,25 @@
 
 const { MESSAGE } = require('triple-beam');
 
+class Printf {
+  constructor(templateFn) {
+    this.template = templateFn;
+  }
+
+  transform(info) {
+    info[MESSAGE] = this.template(info);
+    return info;
+  }
+}
+
 /*
  * function printf (templateFn)
  * Returns a new instance of the printf Format that creates an
  * intermediate prototype to store the template string-based formatter
  * function.
  */
-module.exports = templateFn => {
-  function Printf() {}
-  Printf.prototype.template = templateFn;
-  Printf.prototype.transform = function (info) {
-    info[MESSAGE] = this.template(info);
-    return info;
-  };
+module.exports = opts => new Printf(opts);
 
-  const format = new Printf();
-  format.Format = Printf;
-  return format;
-};
+module.exports.Printf
+  = module.exports.Format
+  = Printf;

--- a/printf.js
+++ b/printf.js
@@ -8,7 +8,7 @@ const { MESSAGE } = require('triple-beam');
  * intermediate prototype to store the template string-based formatter
  * function.
  */
-module.exports = function createPrintf(templateFn) {
+module.exports = templateFn => {
   function Printf() {}
   Printf.prototype.template = templateFn;
   Printf.prototype.transform = function (info) {

--- a/simple.js
+++ b/simple.js
@@ -14,7 +14,7 @@ const { MESSAGE } = require('triple-beam');
  *    ${level}: ${message}                            if rest is empty
  *    ${level}: ${message} ${JSON.stringify(rest)}    otherwise
  */
-module.exports = format(function (info) {
+module.exports = format(info => {
   const stringifiedRest = JSON.stringify(Object.assign({}, info, {
     level: undefined,
     message: undefined,

--- a/splat.js
+++ b/splat.js
@@ -9,7 +9,7 @@ const util = require('util');
  * which performs string interpolation from `info` objects. This was
  * previously exposed implicitly in `winston < 3.0.0`.
  */
-module.exports = format(function (info) {
+module.exports = format(info => {
   if (info.splat) {
     info.message = util.format(info.message, ...info.splat);
   }

--- a/test/colorize.test.js
+++ b/test/colorize.test.js
@@ -7,13 +7,13 @@ const helpers = require('./helpers');
 const { configs } = require('triple-beam');
 const Colorizer = colorize.Colorizer;
 
-describe('colorize', function () {
+describe('colorize', () => {
   before(helpers.setupLevels);
 
   it('colorize() (default)', helpers.assumeFormatted(
     colorize(),
     { level: 'info', message: 'whatever' },
-    function (info) {
+    info => {
       assume(info.level).is.a('string');
       assume(info.message).is.a('string');
       assume(info.level).equals(colors.green('info'));
@@ -24,7 +24,7 @@ describe('colorize', function () {
   it('colorize({ level: true })', helpers.assumeFormatted(
     colorize({ level: true }),
     { level: 'info', message: 'whatever' },
-    function (info) {
+    info => {
       assume(info.level).is.a('string');
       assume(info.message).is.a('string');
       assume(info.level).equals(colors.green('info'));
@@ -35,7 +35,7 @@ describe('colorize', function () {
   it('colorize{ message: true })', helpers.assumeFormatted(
     colorize({ message: true }),
     { level: 'info', message: 'whatever' },
-    function (info) {
+    info => {
       assume(info.level).is.a('string');
       assume(info.message).is.a('string');
       assume(info.level).equals('info');
@@ -46,7 +46,7 @@ describe('colorize', function () {
   it('colorize({ level: true, message: true })', helpers.assumeFormatted(
     colorize({ level: true, message: true }),
     { level: 'info', message: 'whatever' },
-    function (info) {
+    info => {
       assume(info.level).is.a('string');
       assume(info.message).is.a('string');
       assume(info.level).equals(colors.green('info'));
@@ -57,7 +57,7 @@ describe('colorize', function () {
   it('colorize({ all: true })', helpers.assumeFormatted(
     colorize({ all: true }),
     { level: 'info', message: 'whatever' },
-    function (info) {
+    info => {
       assume(info.level).is.a('string');
       assume(info.message).is.a('string');
       assume(info.level).equals(colors.green('info'));
@@ -68,15 +68,15 @@ describe('colorize', function () {
 
 it('exposes the Format prototype', helpers.assumeHasPrototype(colorize));
 
-describe('Colorizer', function () {
-  var expected = Object.assign({},
+describe('Colorizer', () => {
+  const expected = Object.assign({},
     configs.cli.colors,
     configs.npm.colors,
     configs.syslog.colors);
 
   before(helpers.setupLevels);
 
-  it('Colorizer.addColors({ string: string })', function () {
+  it('Colorizer.addColors({ string: string })', () => {
     Colorizer.addColors({ weird: 'cyan' });
 
     assume(Colorizer.allColors).deep.equals(
@@ -84,36 +84,36 @@ describe('Colorizer', function () {
     );
   });
 
-  it('Colorizer.addColors({ string: [Array] })', function () {
+  it('Colorizer.addColors({ string: [Array] })', () => {
     Colorizer.addColors({ multiple: ['red', 'bold'] });
     assume(Colorizer.allColors.multiple).is.an('array');
     assume(Colorizer.allColors.multiple).deep.equals(['red', 'bold']);
   });
 
   // eslint-disable-next-line no-useless-escape
-  it('Colorizer.addColors({ string: "(\w+)/s(\w+)" })', function () {
+  it('Colorizer.addColors({ string: "(\w+)/s(\w+)" })', () => {
     Colorizer.addColors({ delimited: 'blue underline' });
     assume(Colorizer.allColors.delimited).deep.equals(['blue', 'underline']);
   });
 
-  describe('#colorize(level,message)', function () {
+  describe('#colorize(level,message)', () => {
     const instance = new Colorizer();
 
-    it('colorize(level) [single color]', function () {
+    it('colorize(level) [single color]', () => {
       assume(instance.colorize('weird')).equals(colors.cyan('weird'));
     });
 
-    it('colorize(level) [multiple colors]', function () {
+    it('colorize(level) [multiple colors]', () => {
       assume(instance.colorize('multiple')).equals(
         colors.bold(colors.red('multiple'))
       );
     });
 
-    it('colorize(level, message) [single color]', function () {
+    it('colorize(level, message) [single color]', () => {
       assume(instance.colorize('weird', 'message')).equals(colors.cyan('message'));
     });
 
-    it('colorize(level, message) [multiple colors]', function () {
+    it('colorize(level, message) [multiple colors]', () => {
       assume(instance.colorize('multiple', 'message')).equals(
         colors.bold(colors.red('message'))
       );

--- a/test/combine.test.js
+++ b/test/combine.test.js
@@ -1,4 +1,4 @@
-/* eslint max-nested-callbacks: 0 */
+/* eslint-disable max-nested-callbacks */
 'use strict';
 
 const assume = require('assume');
@@ -7,9 +7,9 @@ const label = require('../label');
 const timestamp = require('../timestamp');
 const { formats } = require('./helpers');
 
-describe('combine', function () {
-  describe('combine(...formats)', function () {
-    it('returns a function', function () {
+describe('combine', () => {
+  describe('combine(...formats)', () => {
+    it('returns a function', () => {
       const fmt = combine(
         formats.identity(),
         formats.identity()
@@ -19,7 +19,7 @@ describe('combine', function () {
       assume(fmt.options).deep.equals({});
     });
 
-    it('exposes the Format prototype', function () {
+    it('exposes the Format prototype', () => {
       const fmt = combine(
         formats.identity(),
         formats.identity()
@@ -29,8 +29,8 @@ describe('combine', function () {
       assume(fmt.Format.prototype.transform).is.a('function');
     });
 
-    it('throws an error when provided a non-format', function () {
-      assume(function () {
+    it('throws an error when provided a non-format', () => {
+      assume(() => {
         combine(
           function lolwut() {},
           function notaformat() {}
@@ -39,8 +39,8 @@ describe('combine', function () {
     });
   });
 
-  describe('.transform(info, opts)', function () {
-    it('invokes all intermediary formats', function () {
+  describe('.transform(info, opts)', () => {
+    it('invokes all intermediary formats', () => {
       const labelTimestamp = combine(
         label({ label: 'testing' }),
         timestamp()
@@ -58,7 +58,7 @@ describe('combine', function () {
       assume(actual.label).equals('testing');
     });
 
-    it('{ false } when formats yield [false, obj, obj]', function () {
+    it('{ false } when formats yield [false, obj, obj]', () => {
       const firstFalse = combine(
         formats.ignore(),
         formats.die(),
@@ -71,7 +71,7 @@ describe('combine', function () {
       })).false();
     });
 
-    it('{ false } when formats yield [obj, false, obj]', function () {
+    it('{ false } when formats yield [obj, false, obj]', () => {
       const midFalse = combine(
         formats.identity(),
         formats.ignore(),
@@ -84,7 +84,7 @@ describe('combine', function () {
       })).false();
     });
 
-    it('{ false } when formats yield [obj, obj, false]', function () {
+    it('{ false } when formats yield [obj, obj, false]', () => {
       const lastFalse = combine(
         formats.identity(),
         formats.identity(),

--- a/test/format.test.js
+++ b/test/format.test.js
@@ -5,8 +5,8 @@ const logform = require('../index');
 const { formatFns } = require('./helpers');
 const { format } = logform;
 
-describe('format', function () {
-  it('has the expected default logform.formats', function () {
+describe('format', () => {
+  it('has the expected default logform.formats', () => {
     assume(logform.format).is.a('function');
     assume(logform.format.align).is.a('function');
     assume(logform.format.cli).is.a('function');
@@ -24,25 +24,25 @@ describe('format', function () {
     assume(logform.format.uncolorize).is.a('function');
   });
 
-  describe('format(fn)', function () {
-    it('returns a function', function () {
+  describe('format(fn)', () => {
+    it('returns a function', () => {
       const identity = format(formatFns.identity);
       assume(identity).is.a('function');
     });
 
-    it('exposes the Format prototype', function () {
+    it('exposes the Format prototype', () => {
       const identity = format(formatFns.identity);
       assume(identity.Format).is.a('function');
       assume(identity.Format.prototype.transform).is.a('function');
     });
 
-    it('throws if provided a function of invalid length', function () {
-      assume(function () {
+    it('throws if provided a function of invalid length', () => {
+      assume(() => {
         format(formatFns.invalid);
       }).throws(/Format functions must be synchronous taking a two arguments/);
     });
 
-    it('throws an error including the bad function signature', function () {
+    it('throws an error including the bad function signature', () => {
       const fnsig = formatFns.invalid.toString().split('\n')[0];
       try {
         format(formatFns.invalid);
@@ -51,14 +51,14 @@ describe('format', function () {
       }
     });
 
-    it('format(fn)()', function () {
+    it('format(fn)()', () => {
       const identity = format(formatFns.identity);
       const fmt = identity();
       assume(fmt.transform).is.a('function');
       assume(fmt.options).deep.equals({});
     });
 
-    it('format(fn)(opts)', function () {
+    it('format(fn)(opts)', () => {
       const opts = { testing: true };
       const identity = format(formatFns.identity);
       const fmt = identity(opts);

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -6,7 +6,7 @@ const format = require('../format');
 const levels = require('../levels');
 const { configs } = require('triple-beam');
 
-exports.setupLevels = function () {
+exports.setupLevels = () => {
   levels(configs.cli);
   levels(configs.npm);
   levels(configs.syslog);
@@ -17,26 +17,26 @@ exports.setupLevels = function () {
  * @param {function} write Write function for the specified stream
  * @returns {stream.Writeable} A writeable stream instance
  */
-exports.writeable = function (write) {
-  return new stream.Writable({
-    objectMode: true,
-    write: write
-  });
-};
+exports.writeable = write => (
+  new stream.Writable({
+    write,
+    objectMode: true
+  })
+);
 
 /*
  * Simple test helper which creates an instance
  * of the `colorize` format and asserts that the
  * correct `info` object was processed.
  */
-exports.assumeFormatted = function (format, info, assertion) {
-  return function (done) {
-    var writeable = exports.writeable(function (actual) {
+exports.assumeFormatted = (fmt, info, assertion) => {
+  return done => {
+    const writeable = exports.writeable(actual => {
       assertion(actual, info);
       done();
     });
 
-    writeable.write(format.transform(Object.assign({}, info), format.options));
+    writeable.write(fmt.transform(Object.assign({}, info), fmt.options));
   };
 };
 
@@ -44,8 +44,8 @@ exports.assumeFormatted = function (format, info, assertion) {
  * Assumes that the Factory prototype is exposed on every
  * instance of the format, `fmt`, as `fmt.Format`.
  */
-exports.assumeHasPrototype = function (fmt) {
-  return function assumeFormat() {
+exports.assumeHasPrototype = fmt => {
+  return () => {
     assume(fmt.Format).is.a('function');
     assume(fmt.Format.prototype.transform).is.a('function');
   };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,4 +1,3 @@
-/* eslint no-unused-vars: 0 */
 'use strict';
 
 const assume = require('assume');

--- a/test/json.test.js
+++ b/test/json.test.js
@@ -1,4 +1,3 @@
-/* eslint no-unused-vars: 0 */
 'use strict';
 
 const assume = require('assume');
@@ -6,11 +5,11 @@ const json = require('../json');
 const helpers = require('./helpers');
 const { MESSAGE } = require('triple-beam');
 
-describe('json', function () {
+describe('json', () => {
   it('json() (default) sets info[MESSAGE]', helpers.assumeFormatted(
     json(),
     { level: 'info', message: 'whatever' },
-    function (info, expected) {
+    (info, expected) => {
       assume(info.level).is.a('string');
       assume(info.message).is.a('string');
       assume(info.level).equals('info');
@@ -25,7 +24,7 @@ describe('json', function () {
   it('json({ space: 2 }) sets info[MESSAGE]', helpers.assumeFormatted(
     json({ space: 2 }),
     { level: 'info', message: '2 spaces 4 lyfe' },
-    function (info, expected) {
+    (info, expected) => {
       assume(info.level).is.a('string');
       assume(info.message).is.a('string');
       assume(info.level).equals('info');
@@ -42,7 +41,7 @@ describe('json', function () {
       }
     }),
     { level: 'info', message: 'replacer', filtered: true },
-    function (info, expected) {
+    info => {
       const { level, message } = info;
       assume(info.level).is.a('string');
       assume(info.message).is.a('string');

--- a/test/label.test.js
+++ b/test/label.test.js
@@ -1,4 +1,3 @@
-/* eslint no-unused-vars: 0 */
 'use strict';
 
 const assume = require('assume');
@@ -6,11 +5,11 @@ const label = require('../label');
 const helpers = require('./helpers');
 const { MESSAGE } = require('triple-beam');
 
-describe('label', function () {
+describe('label', () => {
   it('label({ label }) set the label to info.label', helpers.assumeFormatted(
     label({ label: 'wow such impress' }),
     { level: 'info', message: 'label all the things' },
-    function (info, expected) {
+    info => {
       assume(info.level).is.a('string');
       assume(info.message).is.a('string');
       assume(info.label).is.a('string');
@@ -24,7 +23,7 @@ describe('label', function () {
   it('label({ label, message }) adds the label to info.message', helpers.assumeFormatted(
     label({ label: 'wow such impress', message: true }),
     { level: 'info', message: 'label all the things' },
-    function (info, expected) {
+    info => {
       assume(info.level).is.a('string');
       assume(info.message).is.a('string');
       assume(info.level).equals('info');

--- a/test/logstash.test.js
+++ b/test/logstash.test.js
@@ -8,11 +8,11 @@ const helpers = require('./helpers');
 const { MESSAGE } = require('triple-beam');
 const TIMESTAMP = Symbol.for('timestamp');
 
-describe('logstash', function () {
+describe('logstash', () => {
   it('default { @message, @fields } sets info[MESSAGE]', helpers.assumeFormatted(
     logstash(),
     { level: 'info', message: 'whatever' },
-    function (info, expected) {
+    (info, expected) => {
       assume(info.level).equals('info');
       assume(info.message).equals(undefined);
       assume(info[MESSAGE]).equals(JSON.stringify({
@@ -30,7 +30,7 @@ describe('logstash', function () {
       logstash()
     ),
     { level: 'info', message: 'whatever' },
-    function (info, expected) {
+    (info, expected) => {
       assume(info.level).equals('info');
       assume(info.message).equals(undefined);
       assume(info[MESSAGE]).equals(JSON.stringify({

--- a/test/metadata.test.js
+++ b/test/metadata.test.js
@@ -1,4 +1,3 @@
-/* eslint no-unused-vars: 0 */
 'use strict';
 
 const assume = require('assume');
@@ -18,7 +17,7 @@ describe('metadata', () => {
   it('metadata() (default) removes message and level and puts everything else into metadata', helpers.assumeFormatted(
     metadata(),
     testInfoObject,
-    function (info, expected) {
+    info => {
       assume(info.level).is.a('string');
       assume(info.message).is.a('string');
       assume(info.metadata).is.a('object');
@@ -31,7 +30,7 @@ describe('metadata', () => {
   it('metadata({ fillWith: [keys] }) only adds specified keys to the metadata object', helpers.assumeFormatted(
     metadata({ fillWith: ['level', 'someObject'] }),
     testInfoObject,
-    function (info, expected) {
+    info => {
       assume(info.metadata).is.a('object');
       assume(info.metadata.level).equals('info');
       assume(info.metadata.someObject.key).equals('value');
@@ -41,7 +40,7 @@ describe('metadata', () => {
   it('metadata({ fillExcept: [keys] }) fills all but the specified keys in the metadata object', helpers.assumeFormatted(
     metadata({ fillExcept: ['message', 'someObject'] }),
     testInfoObject,
-    function (info, expected) {
+    info => {
       assume(info.message).equals('whatever');
       assume(info.someObject).is.a('object');
       assume(info.someObject.key).equals('value');
@@ -53,7 +52,7 @@ describe('metadata', () => {
   it('metadata({ fillWith: [keys], fillExcept: [keys] }) should only fillExcept the specified keys', helpers.assumeFormatted(
     metadata({ fillWith: ['message'], fillExcept: ['message'] }),
     testInfoObject,
-    function (info, expected) {
+    info => {
       assume(info.message).equals('whatever');
       assume(info.metadata.level).equals('info');
     }
@@ -63,7 +62,7 @@ describe('metadata', () => {
     helpers.assumeFormatted(
       metadata({ fillWith: ['level', 'someKey'], key: 'myCustomKey' }),
       testInfoObject,
-      function (info, expected) {
+      info => {
         assume(info.myCustomKey).is.a('object');
         assume(info.message).equals('whatever');
         assume(info.myCustomKey.level).equals('info');

--- a/test/ms.test.js
+++ b/test/ms.test.js
@@ -1,4 +1,3 @@
-/* eslint no-unused-vars: 0 */
 'use strict';
 
 const assume = require('assume');
@@ -6,11 +5,11 @@ const helpers = require('./helpers');
 const ms = require('../ms');
 const { MESSAGE } = require('triple-beam');
 
-describe('ms', function () {
+describe('ms', () => {
   it('ms() set the ms to info.ms', helpers.assumeFormatted(
     ms(),
     { level: 'info', message: 'time all the things' },
-    function (info, expected) {
+    info => {
       assume(info.level).is.a('string');
       assume(info.message).is.a('string');
       assume(info.ms).is.a('string');

--- a/test/pad-levels.test.js
+++ b/test/pad-levels.test.js
@@ -1,4 +1,3 @@
-/* eslint no-unused-vars: 0 */
 'use strict';
 
 const assume = require('assume');
@@ -7,11 +6,11 @@ const padLevels = require('../pad-levels');
 const { configs, MESSAGE } = require('triple-beam');
 const Padder = padLevels.Padder;
 
-describe('padLevels', function () {
+describe('padLevels', () => {
   it('padLevels({ levels }) set the padding to info.padding', helpers.assumeFormatted(
     padLevels(),
     { level: 'info', message: 'pad all the things' },
-    function (info, expected) {
+    info => {
       assume(info.level).is.a('string');
       assume(info.message).is.a('string');
       assume(info.padding).is.an('object');
@@ -25,7 +24,7 @@ describe('padLevels', function () {
   it('padLevels({ levels }) set the padding to info.padding', helpers.assumeFormatted(
     padLevels({ levels: configs.npm.levels }),
     { level: 'info', message: 'pad all the things' },
-    function (info, expected) {
+    info => {
       assume(info.level).is.a('string');
       assume(info.message).is.a('string');
       assume(info.padding).is.an('object');
@@ -39,7 +38,7 @@ describe('padLevels', function () {
   it('padLevels({ levels, filler }) set the padding to info.padding with a custom filler', helpers.assumeFormatted(
     padLevels({ levels: configs.npm.levels, filler: 'foo' }),
     { level: 'info', message: 'pad all the things' },
-    function (info, expected) {
+    info => {
       assume(info.level).is.a('string');
       assume(info.message).is.a('string');
       assume(info.padding).is.an('object');
@@ -53,14 +52,14 @@ describe('padLevels', function () {
 
 it('exposes the Format prototype', helpers.assumeHasPrototype(padLevels));
 
-describe('Colorizer', function () {
+describe('Colorizer', () => {
   const expected = Object.keys(Object.assign({},
     configs.cli.levels,
     configs.npm.levels,
     configs.syslog.levels
   ));
 
-  it('Padder.addColors({ string: number })', function () {
+  it('Padder.addColors({ string: number })', () => {
     Padder.addPadding(Object.assign({},
       configs.cli.levels,
       configs.npm.levels,
@@ -75,7 +74,7 @@ describe('Colorizer', function () {
     assume(padding[0]).to.equal(' ');
   });
 
-  it('Padder.addColors({ string: number }, string)', function () {
+  it('Padder.addColors({ string: number }, string)', () => {
     Padder.addPadding(Object.assign({},
       configs.cli.levels,
       configs.npm.levels,
@@ -90,10 +89,10 @@ describe('Colorizer', function () {
     assume(padding[0]).to.equal('f');
   });
 
-  describe('#padder(levels, filler)', function () {
+  describe('#padder(levels, filler)', () => {
     const instance = new Padder();
 
-    it('padd(levels) [all levels]', function () {
+    it('padd(levels) [all levels]', () => {
       assume(instance.addPadding(configs.npm.levels)).deep.equals({
         error: '   ',
         warn: '    ',
@@ -105,7 +104,7 @@ describe('Colorizer', function () {
       });
     });
 
-    it('padder(levels, filler) [all levels]', function () {
+    it('padder(levels, filler) [all levels]', () => {
       assume(instance.addPadding(configs.npm.levels, 'foo')).deep.equals({
         error: 'foo',
         warn: 'foof',

--- a/test/pretty-print.test.js
+++ b/test/pretty-print.test.js
@@ -6,11 +6,11 @@ const prettyPrint = require('../pretty-print');
 const helpers = require('./helpers');
 const { MESSAGE } = require('triple-beam');
 
-describe('prettyPrint', function () {
+describe('prettyPrint', () => {
   it('prettyPrint() (default) sets info[MESSAGE]', helpers.assumeFormatted(
     prettyPrint(),
     { level: 'info', message: 'yay template strings are fast' },
-    function (info, expected) {
+    (info, expected) => {
       assume(info.level).is.a('string');
       assume(info.message).is.a('string');
       assume(info.level).equals('info');

--- a/test/printf.test.js
+++ b/test/printf.test.js
@@ -1,4 +1,3 @@
-/* eslint no-unused-vars: 0 */
 'use strict';
 
 const assume = require('assume');
@@ -6,11 +5,11 @@ const printf = require('../printf');
 const helpers = require('./helpers');
 const { MESSAGE } = require('triple-beam');
 
-describe('printf', function () {
+describe('printf', () => {
   it('printf(info => `${template}`) sets info[MESSAGE]', helpers.assumeFormatted(
     printf(info => `${info.level}: ${info.message}`),
     { level: 'info', message: 'yay template strings are fast' },
-    function (info, expected) {
+    info => {
       assume(info.level).is.a('string');
       assume(info.message).is.a('string');
       assume(info.level).equals('info');

--- a/test/simple.test.js
+++ b/test/simple.test.js
@@ -1,4 +1,3 @@
-/* eslint no-unused-vars: 0 */
 'use strict';
 
 const assume = require('assume');
@@ -6,11 +5,11 @@ const simple = require('../simple');
 const helpers = require('./helpers');
 const { MESSAGE } = require('triple-beam');
 
-describe('simple', function () {
+describe('simple', () => {
   it('simple() (default) sets info[MESSAGE]', helpers.assumeFormatted(
     simple(),
     { level: 'info', message: 'whatever' },
-    function (info, expected) {
+    info => {
       assume(info.level).is.a('string');
       assume(info.message).is.a('string');
       assume(info.level).equals('info');
@@ -23,7 +22,7 @@ describe('simple', function () {
   it('simple() strips { splat }', helpers.assumeFormatted(
     simple(),
     { level: 'info', message: 'whatever', splat: [1, 2, 3] },
-    function (info, expected) {
+    info => {
       assume(info.level).is.a('string');
       assume(info.message).is.a('string');
       assume(info.splat).is.an('array');
@@ -38,7 +37,7 @@ describe('simple', function () {
   it('simple() shows { rest }', helpers.assumeFormatted(
     simple(),
     { level: 'info', message: 'whatever', rest: 'something' },
-    function (info, expected) {
+    info => {
       assume(info.level).is.a('string');
       assume(info.message).is.a('string');
       assume(info.rest).is.an('string');

--- a/test/splat.test.js
+++ b/test/splat.test.js
@@ -1,11 +1,8 @@
-/* eslint no-unused-vars: 0 */
 'use strict';
 
 const assume = require('assume');
-const combine = require('../combine');
 const splat = require('../splat');
 const helpers = require('./helpers');
-const { MESSAGE } = require('triple-beam');
 
 /*
  * Helper function for asserting that an info object
@@ -16,7 +13,7 @@ function assumeSplat(message, spread, expected) {
   return helpers.assumeFormatted(
     splat(),
     { level: 'info', message, splat: spread },
-    function (info) {
+    info => {
       assume(info.level).is.a('string');
       assume(info.message).is.a('string');
       assume(Array.isArray(info.splat)).true();
@@ -26,7 +23,7 @@ function assumeSplat(message, spread, expected) {
   );
 }
 
-describe('splat', function () {
+describe('splat', () => {
   it('%s | string placeholder sets info.message', assumeSplat(
     'alright %s', ['what'], 'alright what')
   );

--- a/test/timestamp.test.js
+++ b/test/timestamp.test.js
@@ -1,16 +1,14 @@
-/* eslint no-unused-vars: 0 */
 'use strict';
 
 const assume = require('assume');
 const timestamp = require('../timestamp');
 const helpers = require('./helpers');
-const { MESSAGE } = require('triple-beam');
 
-describe('timestamp', function () {
+describe('timestamp', () => {
   it('timestamp() (default) sets info[timestamp]', helpers.assumeFormatted(
     timestamp(),
     { level: 'info', message: 'whatever', timestamp: new Date().toISOString() },
-    function (info, expected) {
+    info => {
       assume(info.level).is.a('string');
       assume(info.message).is.a('string');
       assume(info.level).equals('info');
@@ -19,14 +17,14 @@ describe('timestamp', function () {
     }
   ));
 
-  it('timestamp({ format: function () { return \'test timestamp\'; } }) sets info[timestamp]', helpers.assumeFormatted(
+  it('timestamp({ format: () => { return \'test timestamp\'; } }) sets info[timestamp]', helpers.assumeFormatted(
     timestamp({
-      format: function () {
+      format: () => {
         return 'test timestamp';
       }
     }),
     { level: 'info', message: 'whatever', timestamp: 'test timestamp' },
-    function (info, expected) {
+    (info, expected) => {
       assume(info.level).is.a('string');
       assume(info.message).is.a('string');
       assume(info.level).equals('info');
@@ -44,7 +42,7 @@ describe('timestamp', function () {
       format: 'YYYY-MM-DD'
     }),
     { level: 'info', message: 'whatever', timestamp: new Date().toISOString() },
-    function (info, expected) {
+    info => {
       assume(info.level).is.a('string');
       assume(info.message).is.a('string');
       assume(info.level).equals('info');

--- a/test/uncolorize.test.js
+++ b/test/uncolorize.test.js
@@ -1,4 +1,3 @@
-/* eslint no-unused-vars: 0 */
 'use strict';
 
 const assume = require('assume');
@@ -39,11 +38,11 @@ function addAndRemoveColors(opts = {}) {
   );
 }
 
-describe('uncolorize', function () {
+describe('uncolorize', () => {
   it('uncolorize() (default) removes all colors', helpers.assumeFormatted(
     addAndRemoveColors(),
     { level: 'info', message: 'whatever' },
-    function (info) {
+    info => {
       assume(info.level).is.a('string');
       assume(info.message).is.a('string');
 
@@ -65,7 +64,7 @@ describe('uncolorize', function () {
   it('uncolorize({ level: false }) removes color from { message, [MESSAGE] }', helpers.assumeFormatted(
     addAndRemoveColors({ level: false }),
     { level: 'info', message: 'whatever' },
-    function (info) {
+    info => {
       assume(info.level).is.a('string');
       assume(info.message).is.a('string');
 
@@ -78,7 +77,7 @@ describe('uncolorize', function () {
   it('uncolorize({ message: false }) removes color from { level, [MESSAGE] }', helpers.assumeFormatted(
     addAndRemoveColors({ message: false }),
     { level: 'info', message: 'whatever' },
-    function (info) {
+    info => {
       assume(info.level).is.a('string');
       assume(info.message).is.a('string');
 
@@ -91,7 +90,7 @@ describe('uncolorize', function () {
   it('uncolorize({ raw: false }) removes color from { level, message }', helpers.assumeFormatted(
     addAndRemoveColors({ raw: false }),
     { level: 'info', message: 'whatever' },
-    function (info) {
+    info => {
       assume(info.level).is.a('string');
       assume(info.message).is.a('string');
 
@@ -104,7 +103,7 @@ describe('uncolorize', function () {
   it('uncolorize({ level: false, message: false }) removes color from [MESSAGE]', helpers.assumeFormatted(
     addAndRemoveColors({ level: false, message: false }),
     { level: 'info', message: 'whatever' },
-    function (info) {
+    info => {
       assume(info.level).is.a('string');
       assume(info.message).is.a('string');
 

--- a/timestamp.js
+++ b/timestamp.js
@@ -11,7 +11,7 @@ const format = require('./format');
  * - { timestamp: true }             // `new Date.toISOString()`
  * - { timestamp: function:String }  // Value returned by `timestamp()`
  */
-module.exports = format(function (info, opts) {
+module.exports = format((info, opts) => {
   if (opts.format) {
     info.timestamp = typeof opts.format === 'function'
       ? opts.format()

--- a/uncolorize.js
+++ b/uncolorize.js
@@ -10,7 +10,7 @@ const { MESSAGE } = require('triple-beam');
  * from `info` objects. This was previously exposed as { stripColors: true }
  * to transports in `winston < 3.0.0`.
  */
-module.exports = format(function (info, opts) {
+module.exports = format((info, opts) => {
   if (opts.level !== false) {
     info.level = colors.strip(info.level);
   }


### PR DESCRIPTION
Not sure why `printf` was implemented the way it was, but I changed it to be an es6-class now.