### PR TITLE
fix combine return value

### DIFF
--- a/combine.js
+++ b/combine.js
@@ -37,8 +37,7 @@ function cascade(formats) {
       }
     }
 
-
-    return info;
+    return obj;
   };
 }
 

--- a/test/combine.test.js
+++ b/test/combine.test.js
@@ -58,6 +58,24 @@ describe('combine', function () {
       assume(actual.label).equals('testing');
     });
 
+    it('return the result of the transformation chain', function () {
+      const assignedInfo = combine(
+        formats.identity(),
+        formats.assign({ key: 'value' }),
+        formats.identity()
+      );
+
+      const info = {
+        level: 'info',
+        message: 'wow such testing'
+      };
+
+      const actual = assignedInfo.transform(Object.assign({}, info));
+      assume(actual.level).equals(info.level);
+      assume(actual.message).equals(info.message);
+      assume(actual.key).is.a('string');
+    });
+
     it('{ false } when formats yield [false, obj, obj]', function () {
       const firstFalse = combine(
         formats.ignore(),

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -60,8 +60,8 @@ exports.formatFns = {
     return info;
   },
 
-  assign(info) {
-    return Object.assign({}, info);
+  assign(info, opts) {
+    return Object.assign({}, info, opts);
   },
 
   // eslint-disable-next-line no-unused-vars


### PR DESCRIPTION
If a transformer does not mutate info but returns a new object the combine function breaks as it returns the original info element.
this causing all the modification done by the transformers after (and including) the one returning a new object to be ignored.