### PR TITLE
Use fast-safe-stringify for perf and to support circular refs

### DIFF
--- a/json.js
+++ b/json.js
@@ -2,6 +2,7 @@
 
 const format = require('./format');
 const { MESSAGE } = require('triple-beam');
+const jsonStringify = require('fast-safe-stringify');
 
 /*
  * function replacer (key, value)
@@ -20,6 +21,6 @@ function replacer(key, value) {
  * to transports in `winston < 3.0.0`.
  */
 module.exports = format((info, opts) => {
-  info[MESSAGE] = JSON.stringify(info, opts.replacer || replacer, opts.space);
+  info[MESSAGE] = jsonStringify(info, opts.replacer || replacer, opts.space);
   return info;
 });

--- a/logstash.js
+++ b/logstash.js
@@ -2,6 +2,7 @@
 
 const format = require('./format');
 const { MESSAGE } = require('triple-beam');
+const jsonStringify = require('fast-safe-stringify');
 
 /*
  * function logstash (info)
@@ -23,6 +24,6 @@ module.exports = format(info => {
   }
 
   logstash['@fields'] = info;
-  info[MESSAGE] = JSON.stringify(logstash);
+  info[MESSAGE] = jsonStringify(logstash);
   return info;
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -741,6 +741,11 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fast-safe-stringify": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.4.tgz",
+      "integrity": "sha512-mNlGUdKOeGNleyrmgbKYtbnCr9KZkZXU7eM89JRo8vY10f7Ul1Fbj07hUBW3N4fC0xM+fmfFfa2zM7mIizhpNQ=="
+    },
     "fecha": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "homepage": "https://github.com/winstonjs/logform#readme",
   "dependencies": {
     "colors": "^1.2.1",
+    "fast-safe-stringify": "^2.0.4",
     "fecha": "^2.3.3",
     "ms": "^2.1.1",
     "triple-beam": "^1.2.0"

--- a/simple.js
+++ b/simple.js
@@ -3,6 +3,7 @@
 
 const format = require('./format');
 const { MESSAGE } = require('triple-beam');
+const jsonStringify = require('fast-safe-stringify');
 
 /*
  * function simple (info)
@@ -15,7 +16,7 @@ const { MESSAGE } = require('triple-beam');
  *    ${level}: ${message} ${JSON.stringify(rest)}    otherwise
  */
 module.exports = format(info => {
-  const stringifiedRest = JSON.stringify(Object.assign({}, info, {
+  const stringifiedRest = jsonStringify(Object.assign({}, info, {
     level: undefined,
     message: undefined,
     splat: undefined

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -13,11 +13,11 @@ exports.setupLevels = () => {
 };
 
 /*
- * Returns a new writeable stream with the specified write function.
+ * Returns a new writable stream with the specified write function.
  * @param {function} write Write function for the specified stream
- * @returns {stream.Writeable} A writeable stream instance
+ * @returns {stream.Writeable} A writable stream instance
  */
-exports.writeable = write => (
+exports.writable = write => (
   new stream.Writable({
     write,
     objectMode: true
@@ -31,12 +31,12 @@ exports.writeable = write => (
  */
 exports.assumeFormatted = (fmt, info, assertion) => {
   return done => {
-    const writeable = exports.writeable(actual => {
+    const writable = exports.writable(actual => {
       assertion(actual, info);
       done();
     });
 
-    writeable.write(fmt.transform(Object.assign({}, info), fmt.options));
+    writable.write(fmt.transform(Object.assign({}, info), fmt.options));
   };
 };
 

--- a/test/json.test.js
+++ b/test/json.test.js
@@ -3,7 +3,7 @@
 const assume = require('assume');
 const json = require('../json');
 const jsonStringify = require('fast-safe-stringify');
-const { assumeFormatted, assumeHasPrototype, writeable } = require('./helpers');
+const { assumeFormatted, assumeHasPrototype, writable } = require('./helpers');
 const { MESSAGE } = require('triple-beam');
 
 describe('json', () => {
@@ -60,8 +60,7 @@ describe('json', () => {
     circular.self = { circular };
 
     const fmt = json();
-    const stream = writeable(info => {
-      const { level, message } = info;
+    const stream = writable(info => {
       assume(info.level).is.a('string');
       assume(info.message).is.a('string');
       assume(info.filtered).equals(true);

--- a/test/json.test.js
+++ b/test/json.test.js
@@ -2,11 +2,12 @@
 
 const assume = require('assume');
 const json = require('../json');
-const helpers = require('./helpers');
+const jsonStringify = require('fast-safe-stringify');
+const { assumeFormatted, assumeHasPrototype, writeable } = require('./helpers');
 const { MESSAGE } = require('triple-beam');
 
 describe('json', () => {
-  it('json() (default) sets info[MESSAGE]', helpers.assumeFormatted(
+  it('json() (default) sets info[MESSAGE]', assumeFormatted(
     json(),
     { level: 'info', message: 'whatever' },
     (info, expected) => {
@@ -21,7 +22,7 @@ describe('json', () => {
     }
   ));
 
-  it('json({ space: 2 }) sets info[MESSAGE]', helpers.assumeFormatted(
+  it('json({ space: 2 }) sets info[MESSAGE]', assumeFormatted(
     json({ space: 2 }),
     { level: 'info', message: '2 spaces 4 lyfe' },
     (info, expected) => {
@@ -33,7 +34,7 @@ describe('json', () => {
     }
   ));
 
-  it('json({ replacer }) sets info[MESSAGE]', helpers.assumeFormatted(
+  it('json({ replacer }) sets info[MESSAGE]', assumeFormatted(
     json({
       replacer: function onlyLevelAndMessage(key, value) {
         if (key === 'filtered') { return undefined; }
@@ -52,5 +53,27 @@ describe('json', () => {
     }
   ));
 
-  it('exposes the Format prototype', helpers.assumeHasPrototype(json));
+
+  it('json() can handle circular JSON objects', (done) => {
+    // Define an info with a circular reference.
+    const circular = { level: 'info', message: 'has a circular ref ok!', filtered: true };
+    circular.self = { circular };
+
+    const fmt = json();
+    const stream = writeable(info => {
+      const { level, message } = info;
+      assume(info.level).is.a('string');
+      assume(info.message).is.a('string');
+      assume(info.filtered).equals(true);
+      assume(info.level).equals('info');
+      assume(info.message).equals('has a circular ref ok!');
+      assume(info.self.circular).equals(circular);
+      assume(info[MESSAGE]).equals(jsonStringify(circular));
+      done();
+    });
+
+    stream.write(fmt.transform(circular, fmt.options));
+  });
+
+  it('exposes the Format prototype', assumeHasPrototype(json));
 });


### PR DESCRIPTION
While catching up with @davidmarkclements at JSConf I was reminding that `fast-safe-stringify` is a great piece of code we should use by default. This PR:

- [x] Uses `fast-safe-stringify` instead of `JSON.stringify`
- [x] Adds a test for circular JSON since **bonus** `fast-safe-stringify` _also_ supports circular JSON refs 🎉 
- [x] Renames `writeable` to `writable` within internal test code to be consistent with Node core naming conventions.

I tip my hat to @davidmarkclements here for doing all the heavy lifting:

**Before**
```
==========
OBJECT benchmark averages
BunyanObj average: 706.089ms
WinstonObj average: 519.757ms
BoleObj average: 291.980ms
LogLevelObject average: 556.841ms
PinoObj average: 279.025ms
PinoUnsafeObj average: 277.313ms
PinoExtremeObj average: 154.406ms
PinoUnsafeExtremeObj average: 151.695ms
==========
```

**After**
```
==========
OBJECT benchmark averages
BunyanObj average: 727.584ms
WinstonObj average: 446.947ms
BoleObj average: 309.041ms
LogLevelObject average: 577.650ms
PinoObj average: 282.819ms
PinoUnsafeObj average: 282.245ms
PinoExtremeObj average: 155.538ms
PinoUnsafeExtremeObj average: 148.020ms
==========
```

That's almost a 20% gain on that benchmark. 💯 