### PR TITLE
Match expectations from `winston@2.x` for padLevels. Use that for proper CLI format

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,16 +1,52 @@
 'use strict';
 
-const format = require('./format');
-const colorize = require('./colorize');
-const padLevels = require('./pad-levels');
+const { Colorizer } = require('./colorize');
+const { Padder } = require('./pad-levels');
+const { configs, MESSAGE } = require('triple-beam');
+
+
+/**
+ * Cli format class that handles initial state for a a separate
+ * Colorizer and Padder instance.
+ */
+class CliFormat {
+  constructor(opts = {}) {
+    if (!opts.levels) {
+      opts.levels = configs.npm.levels;
+    }
+
+    this.colorizer = new Colorizer(opts);
+    this.padder = new Padder(opts);
+    this.options = opts;
+  }
+
+  /*
+   * function transform (info, opts)
+   * Attempts to both:
+   * 1. Pad the { level }
+   * 2. Colorize the { level, message }
+   * of the given `logform` info object depending on the `opts`.
+   */
+  transform(info, opts) {
+    this.colorizer.transform(
+      this.padder.transform(info, opts),
+      opts
+    );
+
+    info[MESSAGE] = `${info.level}:${info.message}`;
+    return info;
+  }
+}
 
 /*
- * function cli (info)
+ * function cli (opts)
  * Returns a new instance of the CLI format that turns a log
  * `info` object into the same format previously available
  * in `winston.cli()` in `winston < 3.0.0`.
  */
-module.exports = format(
-  colorize(),
-  padLevels()
-);
+module.exports = opts => new CliFormat(opts);
+
+//
+// Attach the CliFormat for registration purposes
+//
+module.exports.Format = CliFormat;

--- a/colorize.js
+++ b/colorize.js
@@ -14,11 +14,11 @@ colors.enabled = true;
  */
 const hasSpace = /\s+/;
 
+/*
+ * Colorizer format. Wraps the `level` and/or `message` properties
+ * of the `info` objects with ANSI color codes based on a few options.
+ */
 class Colorizer {
-  /*
-   * function setupColors(info)
-   * Attaches a Colorizer instance to the format.
-   */
   constructor(opts = {}) {
     if (opts.colors) {
       this.addColors(opts.colors);

--- a/combine.js
+++ b/combine.js
@@ -57,3 +57,10 @@ module.exports = (...formats) => {
   instance.Format = combinedFormat.Format;
   return instance;
 };
+
+//
+// Export the cascade method for use in cli and other
+// combined formats that should not be assumed to be
+// singletons.
+//
+module.exports.cascade = cascade;

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const assume = require('assume');
+const colors = require('colors/safe');
+const cli = require('../cli');
+const {
+  assumeFormatted,
+  assumeHasPrototype,
+  infoify,
+  setupLevels
+} = require('./helpers');
+const { LEVEL, MESSAGE } = require('triple-beam');
+
+describe('cli', () => {
+  before(setupLevels);
+
+  it('cli() (default) sets info[MESSAGE]', assumeFormatted(
+    cli(),
+    infoify({ level: 'info', message: 'whatever' }),
+    (info) => {
+      assume(info.level).is.a('string');
+      assume(info.message).is.a('string');
+      assume(info.level).equals(colors.green('info'));
+      assume(info.message).equals('    whatever');
+
+      assume(info[LEVEL]).is.a('string');
+      assume(info[MESSAGE]).is.a('string');
+      assume(info[LEVEL]).equals('info');
+      assume(info[MESSAGE]).equals(`${colors.green('info')}:    whatever`);
+    }
+  ));
+
+  it('exposes the Format prototype', assumeHasPrototype(cli));
+});

--- a/test/colorize.test.js
+++ b/test/colorize.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const assume = require('assume');
-const colors = require('colors');
+const colors = require('colors/safe');
 const { configs, LEVEL } = require('triple-beam');
 const colorize = require('../colorize');
 const Colorizer = colorize.Colorizer;

--- a/test/combine.test.js
+++ b/test/combine.test.js
@@ -8,6 +8,10 @@ const timestamp = require('../timestamp');
 const { formats } = require('./helpers');
 
 describe('combine', () => {
+  it('exposes the cascade function', () => {
+    assume(combine.cascade).is.a('function');
+  });
+
   describe('combine(...formats)', () => {
     it('returns a function', () => {
       const fmt = combine(

--- a/test/pad-levels.test.js
+++ b/test/pad-levels.test.js
@@ -1,119 +1,93 @@
 'use strict';
 
 const assume = require('assume');
-const helpers = require('./helpers');
+const {
+  assumeFormatted,
+  assumeHasPrototype,
+  infoify
+} = require('./helpers');
 const padLevels = require('../pad-levels');
 const { configs, MESSAGE } = require('triple-beam');
 const Padder = padLevels.Padder;
 
+const longLevels = Object.assign({}, configs.npm.levels);
+longLevels['really-really-long'] = 7;
+
 describe('padLevels', () => {
-  it('padLevels({ levels }) set the padding to info.padding', helpers.assumeFormatted(
+  it('padLevels({ levels }) set the padding to info.padding', assumeFormatted(
     padLevels(),
-    { level: 'info', message: 'pad all the things' },
+    infoify({ level: 'info', message: 'pad all the things' }),
     info => {
       assume(info.level).is.a('string');
       assume(info.message).is.a('string');
-      assume(info.padding).is.an('object');
       assume(info.level).equals('info');
-      assume(info.padding[info.level]).equals('    ');
-      assume(info.message).equals('pad all the things');
-      assume(info[MESSAGE]).equals(undefined);
+      assume(info.message).equals('    pad all the things');
+      assume(info[MESSAGE]).equals('    pad all the things');
     }
   ));
 
-  it('padLevels({ levels }) set the padding to info.padding', helpers.assumeFormatted(
-    padLevels({ levels: configs.npm.levels }),
-    { level: 'info', message: 'pad all the things' },
+  it('padLevels({ levels }) set the padding to info.padding', assumeFormatted(
+    padLevels({ levels: longLevels }),
+    infoify({ level: 'info', message: 'pad all the things' }),
     info => {
       assume(info.level).is.a('string');
       assume(info.message).is.a('string');
-      assume(info.padding).is.an('object');
       assume(info.level).equals('info');
-      assume(info.padding[info.level]).equals('    ');
-      assume(info.message).equals('pad all the things');
-      assume(info[MESSAGE]).equals(undefined);
+
+      assume(info.message).equals('               pad all the things');
+      assume(info[MESSAGE]).equals('               pad all the things');
     }
   ));
 
-  it('padLevels({ levels, filler }) set the padding to info.padding with a custom filler', helpers.assumeFormatted(
+  it('padLevels({ levels, filler }) set the padding to info.padding with a custom filler', assumeFormatted(
     padLevels({ levels: configs.npm.levels, filler: 'foo' }),
-    { level: 'info', message: 'pad all the things' },
+    infoify({ level: 'info', message: 'pad all the things' }),
     info => {
       assume(info.level).is.a('string');
       assume(info.message).is.a('string');
-      assume(info.padding).is.an('object');
       assume(info.level).equals('info');
-      assume(info.padding[info.level]).equals('foof');
-      assume(info.message).equals('pad all the things');
-      assume(info[MESSAGE]).equals(undefined);
+      assume(info.message).equals('foofpad all the things');
+      assume(info[MESSAGE]).equals('foofpad all the things');
     }
   ));
+
+  it('exposes the Format prototype', assumeHasPrototype(padLevels));
 });
 
-it('exposes the Format prototype', helpers.assumeHasPrototype(padLevels));
-
-describe('Colorizer', () => {
+describe('Padder', () => {
   const expected = Object.keys(Object.assign({},
     configs.cli.levels,
     configs.npm.levels,
     configs.syslog.levels
   ));
 
-  it('Padder.addColors({ string: number })', () => {
-    Padder.addPadding(Object.assign({},
+  it('Padder.paddingForLevels({ string: number })', () => {
+    const paddings = Padder.paddingForLevels(Object.assign({},
       configs.cli.levels,
       configs.npm.levels,
       configs.syslog.levels
     ));
 
-    const keys = Object.keys(Padder.allPadding);
+    const keys = Object.keys(paddings);
     assume(keys).deep.equals(expected);
 
-    const padding = Padder.allPadding[keys.pop()];
+    const padding = paddings[keys.pop()];
     assume(padding).to.be.a('string');
     assume(padding[0]).to.equal(' ');
   });
 
-  it('Padder.addColors({ string: number }, string)', () => {
-    Padder.addPadding(Object.assign({},
+  it('Padder.paddingForLevels({ string: number }, string)', () => {
+    const paddings = Padder.paddingForLevels(Object.assign({},
       configs.cli.levels,
       configs.npm.levels,
       configs.syslog.levels
     ), 'foo');
 
-    const keys = Object.keys(Padder.allPadding);
+    const keys = Object.keys(paddings);
     assume(keys).deep.equals(expected);
 
-    const padding = Padder.allPadding[keys.pop()];
+    const padding = paddings[keys.pop()];
     assume(padding).to.be.a('string');
     assume(padding[0]).to.equal('f');
-  });
-
-  describe('#padder(levels, filler)', () => {
-    const instance = new Padder();
-
-    it('padd(levels) [all levels]', () => {
-      assume(instance.addPadding(configs.npm.levels)).deep.equals({
-        error: '   ',
-        warn: '    ',
-        info: '    ',
-        http: '    ',
-        verbose: ' ',
-        debug: '   ',
-        silly: '   '
-      });
-    });
-
-    it('padder(levels, filler) [all levels]', () => {
-      assume(instance.addPadding(configs.npm.levels, 'foo')).deep.equals({
-        error: 'foo',
-        warn: 'foof',
-        info: 'foof',
-        http: 'foof',
-        verbose: 'f',
-        debug: 'foo',
-        silly: 'foo'
-      });
-    });
   });
 });

--- a/test/uncolorize.test.js
+++ b/test/uncolorize.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const assume = require('assume');
-const colors = require('colors');
+const colors = require('colors/safe');
 const colorize = require('../colorize');
 const combine = require('../combine');
 const format = require('../format');


### PR DESCRIPTION
> Fixes #36.

This PR does the following:

- [x] Exposes `cascade` from `combine` for usage by formats if necessary
- [x] Corrects requirements mismatch for `padLevels`. The previous implementation of `padLevels` in `logform` had set a paddings object on the `info` but had not actually applied the padding. This was missed in the initial PR review, but was not aligned with the expected functionality that `winston@2.x` exposed to folks. This has been corrected.
- [x] Creates a proper `cli` format using a class with a `Colorizer` and `Padder`. Fixes #36.
