### PR TITLE
Migrate functionality from winston Logger to splat format.

### DIFF
--- a/splat.js
+++ b/splat.js
@@ -9,7 +9,7 @@ const { SPLAT } = require('triple-beam');
  * https://github.com/nodejs/node/blob/b1c8f15c5f169e021f7c46eb7b219de95fe97603/lib/util.js#L201-L230
  * @type {RegExp}
  */
-const formatRegExp = /%[sdjifoO%]/g;
+const formatRegExp = /%[scdjifoO%]/g;
 
 /**
  * Captures the number of escaped % signs in a format string (i.e. %s strings).

--- a/splat.js
+++ b/splat.js
@@ -1,7 +1,101 @@
 'use strict';
 
-const format = require('./format');
 const util = require('util');
+const { SPLAT } = require('triple-beam');
+
+/**
+ * Captures the number of format (i.e. %s strings) in a given string.
+ * Based on `util.format`, see Node.js source:
+ * https://github.com/nodejs/node/blob/b1c8f15c5f169e021f7c46eb7b219de95fe97603/lib/util.js#L201-L230
+ * @type {RegExp}
+ */
+const formatRegExp = /%[sdjifoO%]/g;
+
+/**
+ * Captures the number of escaped % signs in a format string (i.e. %s strings).
+ * @type {RegExp}
+ */
+const escapedPercent = /%%/g;
+
+class Splatter {
+  constructor(opts) {
+    this.options = opts;
+  }
+
+  /**
+   * Check to see if tokens <= splat.length, assign { splat, meta } into the
+   * `info` accordingly, and write to this instance.
+   *
+   * @param  {Info} info Logform info message.
+   * @param  {String[]} tokens Set of string interpolation tokens.
+   * @returns {Info} Modified info message
+   * @private
+   */
+  _splat(info, tokens) {
+    const msg = info.message;
+    const splat = info[SPLAT];
+    const percents = msg.match(escapedPercent);
+    const escapes = percents && percents.length || 0;
+
+    // The expected splat is the number of tokens minus the number of escapes
+    // e.g.
+    // - { expectedSplat: 3 } '%d %s %j'
+    // - { expectedSplat: 5 } '[%s] %d%% %d%% %s %j'
+    //
+    // Any "meta" will be arugments in addition to the expected splat size
+    // regardless of type. e.g.
+    //
+    // logger.log('info', '%d%% %s %j', 100, 'wow', { such: 'js' }, { thisIsMeta: true });
+    // would result in splat of four (4), but only three (3) are expected. Therefore:
+    //
+    // extraSplat = 3 - 4 = -1
+    // metas = [100, 'wow', { such: 'js' }, { thisIsMeta: true }].splice(-1, -1 * -1);
+    // splat = [100, 'wow', { such: 'js' }]
+    const expectedSplat = tokens.length - escapes;
+    const extraSplat = expectedSplat - splat.length;
+    const metas = extraSplat < 0
+      ? splat.splice(extraSplat, -1 * extraSplat)
+      : [];
+
+    // Now that { splat } has been separated from any potential { meta }. we
+    // can assign this to the `info` object and write it to our format stream.
+    if (metas.length === 1) {
+      info.meta = metas[0];
+    } else {
+      info.meta = metas;
+    }
+
+    info.message = util.format(msg, ...splat);
+    return info;
+  }
+
+  /**
+   * Transforms the `info` message by using `util.format` to complete
+   * any `info.message` provided it has string interpolation tokens.
+   * If no tokens exist then `info` is immutable.
+   *
+   * @param  {Info} info Logform info message.
+   * @param  {Object} opts Options for this instance.
+   * @returns {Info} Modified info message
+   */
+  transform(info) {
+    const msg = info.message;
+    const splat = info[SPLAT];
+
+    // Evaluate if the message has any interpolation tokens. If not,
+    // then let evaluation continue.
+    const tokens = msg && msg.match && msg.match(formatRegExp);
+    if (!tokens && (!splat || !splat.length)) {
+      return info;
+    }
+
+    if (tokens) {
+      return this._splat(info, tokens);
+    }
+
+    return info;
+  }
+}
 
 /*
  * function splat (info)
@@ -9,10 +103,4 @@ const util = require('util');
  * which performs string interpolation from `info` objects. This was
  * previously exposed implicitly in `winston < 3.0.0`.
  */
-module.exports = format(info => {
-  if (info.splat) {
-    info.message = util.format(info.message, ...info.splat);
-  }
-
-  return info;
-});
+module.exports = opts => new Splatter(opts);

--- a/test/splat.test.js
+++ b/test/splat.test.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { SPLAT } = require('triple-beam');
 const assume = require('assume');
 const splat = require('../splat');
 const helpers = require('./helpers');
@@ -12,11 +13,16 @@ const helpers = require('./helpers');
 function assumeSplat(message, spread, expected) {
   return helpers.assumeFormatted(
     splat(),
-    { level: 'info', message, splat: spread },
+    { level: 'info', message, [SPLAT]: spread },
     info => {
       assume(info.level).is.a('string');
       assume(info.message).is.a('string');
-      assume(Array.isArray(info.splat)).true();
+      assume(Array.isArray(info[SPLAT])).true();
+
+      // Prefer any user-defined assertion (if provided).
+      if (typeof expected === 'function') {
+        return expected(info);
+      }
 
       assume(info.message).equals(expected);
     }
@@ -25,24 +31,38 @@ function assumeSplat(message, spread, expected) {
 
 describe('splat', () => {
   it('%s | string placeholder sets info.message', assumeSplat(
-    'alright %s', ['what'], 'alright what')
-  );
+    'alright %s', ['what'], 'alright what'
+  ));
 
   it('%d | number placeholder sets info.message', assumeSplat(
-    'test message %d', [123], 'test message 123')
-  );
+    'test message %d', [123], 'test message 123'
+  ));
 
   it('%j | json placeholder sets info.message', assumeSplat(
-    'test %j', [{ number: 123 }], 'test {"number":123}')
-  );
+    'test %j', [{ number: 123 }], 'test {"number":123}'
+  ));
 
   it('%% | escaped % sets info.message', assumeSplat(
-    'test %d%%', [100], 'test 100%')
-  );
+    'test %d%%', [100], 'test 100%'
+  ));
+
+  it('no % and no splat | returns the same info', assumeSplat(
+    'nothing to see here', [], 'nothing to see here'
+  ));
+
+  it('no % but some splat | returns the same info', assumeSplat(
+    'Look! No tokens!', ['ok'], info => {
+      assume(info.message).equals('Look! No tokens!');
+      assume(info.meta).equals(undefined);
+    }
+  ));
 
   it('Splat overflow (too many arguments) sets info.message', assumeSplat(
     '%s #%d, how are you %s',
     ['Hi', 42, 'feeling', { today: true }],
-    'Hi #42, how are you feeling { today: true }'
+    info => {
+      assume(info.message).equals('Hi #42, how are you feeling');
+      assume(info.meta).deep.equals({ today: true });
+    }
   ));
 });


### PR DESCRIPTION
Ensures that from a performance perspective folks only get splat interpolation if they turn it on.