### PR TITLE
splat formatter: Don't break when there are % placeholders but no values

### DIFF
--- a/splat.js
+++ b/splat.js
@@ -33,7 +33,7 @@ class Splatter {
    */
   _splat(info, tokens) {
     const msg = info.message;
-    const splat = info[SPLAT];
+    const splat = info[SPLAT] || [];
     const percents = msg.match(escapedPercent);
     const escapes = percents && percents.length || 0;
 


### PR DESCRIPTION
I'm trying to upgrade to Winston 3, but hit a snag because we're logging some database statements that contain `%s` in some cases.

Here's a very reduced example:

```js
const winston = require('winston');

const logger = winston.createLogger({
  format: winston.format.combine(
    winston.format.colorize(),
    winston.format.splat(),
    winston.format.simple(),
    winston.format.printf(({level, message}) => `${level}: ${message}`)
  ),
  transports: [
    new winston.transports.Console()
  ]
});

logger.info('foo %s');
```

Breaks with:

```
TypeError: Cannot read property 'length' of undefined
    at Splatter._splat (/myproject/node_modules/logform/splat.js:55:46)
    at Splatter.transform (/myproject/node_modules/logform/splat.js:93:19)
    at Format.info [as transform] (/myproject/node_modules/logform/combine.js:20:24)
    at DerivedLogger._transform (/myproject/node_modules/winston/lib/winston/logger.js:210:29)
    at DerivedLogger.Transform._read (/myproject/node_modules/winston/node_modules/readable-stream/lib/_stream_transform.js:184:10)
    at DerivedLogger.Transform._write (/myproject/node_modules/winston/node_modules/readable-stream/lib/_stream_transform.js:172:83)
    at doWrite (/myproject/node_modules/winston/node_modules/readable-stream/lib/_stream_writable.js:428:64)
    at writeOrBuffer (/myproject/node_modules/winston/node_modules/readable-stream/lib/_stream_writable.js:417:5)
    at DerivedLogger.Writable.write (/myproject/node_modules/winston/node_modules/readable-stream/lib/_stream_writable.js:334:11)
    at DerivedLogger.(anonymous function).args [as info] (/myproject/node_modules/winston/lib/winston/create-logger.js:54:16)
```

It seems like the `%s` should just be left in the message in that case, similar to the Winston 2 behavior, or when few values are provided:

```js
logger.info('foo %s %s', 'abc'); // Logs "foo abc %s"
```

My current workaround is to add another transform that makes sure that there's at least an empty array of splats:

```js
const winston = require('winston');
const symbolForSplat = Symbol.for('splat');

const logger = winston.createLogger({
  format: winston.format.combine(
    winston.format.colorize(),
    {
      transform(log) {
        log[symbolForSplat] = log[symbolForSplat] || [];
        return log;
      }
    },
    winston.format.splat(),
    winston.format.simple(),
    winston.format.printf(({level, message}) => `${level}: ${message}`)
  ),
  transports: [
    new winston.transports.Console()
  ]
});
```

... but I thought it'd be nicer to handle this in the library itself, so here goes :)