### PR TITLE
routing info through splat logic regardless of whether tokens exist t…

### DIFF
--- a/splat.js
+++ b/splat.js
@@ -82,18 +82,15 @@ class Splatter {
     const msg = info.message;
     const splat = info[SPLAT];
 
-    // Evaluate if the message has any interpolation tokens. If not,
-    // then let evaluation continue.
-    const tokens = msg && msg.match && msg.match(formatRegExp);
-    if (!tokens && (!splat || !splat.length)) {
+    // No need to process anything if splat is undefined
+    if (!splat || !splat.length) {
       return info;
     }
 
-    if (tokens) {
-      return this._splat(info, tokens);
-    }
-
-    return info;
+    // Extract tokens, if none available default to empty array to
+    // ensure consistancy in expected results
+    const tokens = msg && msg.match && msg.match(formatRegExp) || [];
+    return this._splat(info, tokens);
   }
 }
 

--- a/test/splat.test.js
+++ b/test/splat.test.js
@@ -54,13 +54,16 @@ describe('splat', () => {
   ));
 
   it('no % and no splat | returns the same info', assumeSplat(
-    'nothing to see here', [], 'nothing to see here'
+    'nothing to see here', [], info => {
+      assume(info.message).equals('nothing to see here');
+      assume(info.meta).equals(undefined);
+    }
   ));
 
   it('no % but some splat | returns the same info', assumeSplat(
     'Look! No tokens!', ['ok'], info => {
       assume(info.message).equals('Look! No tokens!');
-      assume(info.meta).equals(undefined);
+      assume(info.meta).equals('ok');
     }
   ));
 


### PR DESCRIPTION
routing info through splat logic regardless of whether tokens exist t…o ensure consistency in expected results. the documentation for format.splat() states that unused splat arguments are moved to meta. I would expect that the same logic should apply whether or not the message actually contains tokens.