### PR TITLE
Strip info[LEVEL] in prettyPrint; fixes #31

### DIFF
--- a/pretty-print.js
+++ b/pretty-print.js
@@ -2,7 +2,7 @@
 
 const inspect = require('util').inspect;
 const format = require('./format');
-const { MESSAGE } = require('triple-beam');
+const { LEVEL, MESSAGE } = require('triple-beam');
 
 /*
  * function prettyPrint (info)
@@ -11,6 +11,9 @@ const { MESSAGE } = require('triple-beam');
  * { prettyPrint: true } to transports in `winston < 3.0.0`.
  */
 module.exports = format((info, opts) => {
-  info[MESSAGE] = inspect(info, false, opts.depth || null, opts.colorize);
+  // info[LEVEL] is enumerable here, so util.inspect would print it; so it must be manually stripped
+  const strippedInfo = Object.assign({}, info);
+  delete strippedInfo[LEVEL];
+  info[MESSAGE] = inspect(strippedInfo, false, opts.depth || null, opts.colorize);
   return info;
 });


### PR DESCRIPTION
The most elegant way to do this seems to involve a clone of `info`, which is potentially another performance hit.  But Node.js docs already clearly say to not rely on util.inspect for production, so as long as we echo that for `prettyPrint`, I'm ok with this.