### PR TITLE
Try better fix for #1485

### DIFF
--- a/splat.js
+++ b/splat.js
@@ -73,14 +73,14 @@ class Splatter {
   }
 
   /**
-     * Transforms the `info` message by using `util.format` to complete
-     * any `info.message` provided it has string interpolation tokens.
-     * If no tokens exist then `info` is immutable.
-     *
-     * @param  {Info} info Logform info message.
-     * @param  {Object} opts Options for this instance.
-     * @returns {Info} Modified info message
-     */
+    * Transforms the `info` message by using `util.format` to complete
+    * any `info.message` provided it has string interpolation tokens.
+    * If no tokens exist then `info` is immutable.
+    *
+    * @param  {Info} info Logform info message.
+    * @param  {Object} opts Options for this instance.
+    * @returns {Info} Modified info message
+    */
   transform(info) {
     const msg = info.message;
     const splat = info[SPLAT] || info.splat;

--- a/splat.js
+++ b/splat.js
@@ -60,9 +60,9 @@ class Splatter {
     // Now that { splat } has been separated from any potential { meta }. we
     // can assign this to the `info` object and write it to our format stream.
     if (metas.length === 1) {
-      info.meta = metas[0];
+      Object.assign(info, metas[0]);
     } else if (metas.length) {
-      info.meta = metas;
+      Object.assign(info, metas);
     }
 
     info.message = util.format(msg, ...splat);

--- a/splat.js
+++ b/splat.js
@@ -59,10 +59,13 @@ class Splatter {
 
     // Now that { splat } has been separated from any potential { meta }. we
     // can assign this to the `info` object and write it to our format stream.
-    if (metas.length === 1) {
-      Object.assign(info, metas[0]);
-    } else if (metas.length) {
-      Object.assign(info, metas);
+    // If the additional metas are **NOT** objects or **LACK** enumerable properties
+    // you are going to have a bad time.
+    const metalen = metas.length;
+    if (metalen) {
+      for (let i = 0; i < metalen; i++) {
+        Object.assign(info, metas[i]);
+      }
     }
 
     info.message = util.format(msg, ...splat);
@@ -100,11 +103,15 @@ class Splatter {
 
       // Now that { splat } has been separated from any potential { meta }. we
       // can assign this to the `info` object and write it to our format stream.
-      if (metas.length === 1) {
-        info.meta = metas[0];
-      } else if (metas.length) {
-        info.meta = metas;
+      // If the additional metas are **NOT** objects or **LACK** enumerable properties
+      // you are going to have a bad time.
+      const metalen = metas.length;
+      if (metalen) {
+        for (let i = 0; i < metalen; i++) {
+          Object.assign(info, metas[i]);
+        }
       }
+
       return info;
     }
 

--- a/test/splat.test.js
+++ b/test/splat.test.js
@@ -56,7 +56,9 @@ describe('splat', () => {
   it('more arguments than % | multiple "meta"', assumeSplat(
     'test %j', [{ number: 123 }, { an: 'object' }, ['an', 'array']], info => {
       assume(info.message).equals('test {"number":123}');
-      assume(info.meta).deep.equals([{ an: 'object' }, ['an', 'array']]);
+      assume(info.an).equals('object');
+      assume(info[0]).equals('an');
+      assume(info[1]).equals('array');
     }
   ));
 
@@ -64,17 +66,19 @@ describe('splat', () => {
     'test %d%%', [100], 'test 100%'
   ));
 
-  it('no % and one object | returns the message and meta', assumeSplat(
+  it('no % and one object | returns the message and properties', assumeSplat(
     'see an object', [{ an: 'object' }], info => {
       assume(info.message).equals('see an object');
-      assume(info.meta).deep.equals({ an: 'object' });
+      assume(info.an).equals('object');
     }
   ));
 
-  it('no % and two objects | returns the string and two objects', assumeSplat(
+  it('no % and two objects | returns the string and all properties', assumeSplat(
     'lots to see here', [{ an: 'object' }, ['an', 'array']], info => {
       assume(info.message).equals('lots to see here');
-      assume(info.meta).deep.equals([{ an: 'object' }, ['an', 'array']]);
+      assume(info.an).equals('object');
+      assume(info[0]).equals('an');
+      assume(info[1]).equals('array');
     }
   ));
 
@@ -85,10 +89,11 @@ describe('splat', () => {
     }
   ));
 
-  it('no % but some splat | returns the same info', assumeSplat(
+  it('no % but some splat | returns the same message with new properties', assumeSplat(
     'Look! No tokens!', ['ok'], info => {
       assume(info.message).equals('Look! No tokens!');
-      assume(info.meta).equals('ok');
+      assume(info[0]).equals('o');
+      assume(info[1]).equals('k');
     }
   ));
 
@@ -97,7 +102,7 @@ describe('splat', () => {
     ['Hi', 42, 'feeling', { today: true }],
     info => {
       assume(info.message).equals('Hi #42, how are you feeling');
-      assume(info.meta).deep.equals({ today: true });
+      assume(info.today).true();
     }
   ));
 


### PR DESCRIPTION
I can no longer log a single object as a splat:
`logger.info('hey %O', obj);`
doesn't format the splat right anymore...

But I also want this to work:
```js
const winston = require('winston');

let transports = {
  console: new winston.transports.Console({level: 'info'})
};

let {format} = winston;
let logger = winston.createLogger({
  format: format.combine(
    format.splat(),
    format.printf(info => `[${info.label}]: ${info.message}`)
  ),
  transports: [transports.console]
});

logger.log(
  'info',
  'let\'s %s some %s',
  'interpolate',
  'splat parameters',
  {label: 'label!'},
);
// [label!]: let's interpolate some splat parameters
```

This PR and an associated one in winston make both of these cases work, but @indexzero would be good if you could opine.  IIRC in 3.x we shouldn't be assigning to info.meta like this...