### PR TITLE
Add error normalizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ const alignedWithColorsAndTime = format.combine(
   - [CLI](#cli)
   - [Colorize](#colorize)
   - [Combine](#combine)
+  - [Errors](#errors)
   - [JSON](#json)
   - [Label](#label)
   - [Logstash](#logstash)
@@ -274,6 +275,35 @@ console.log(info);
 //   timestamp: '2018-10-02T15:03:14.230Z',
 //   [Symbol(message)]:
 //    '{"level":"info","message":"my message","timestamp":"2018-10-02T15:03:14.230Z"}' }
+```
+
+### Errors
+
+The `errors` format allows you to pass in an instance of a JavaScript `Error` directly to the logger.
+It allows you to specify whether not to include the stack-trace.
+
+```js
+const { format } = require('logform')
+const { errors } = format
+
+const errorsFormat = errors({ stack: true })
+
+const err = new Error('Oh no!')
+
+const info = errorsFormat.transform(err)
+
+console.log(info)
+// Error: Oh no!
+//     at repl:1:13
+//     at ContextifyScript.Script.runInThisContext (vm.js:50:33)
+//     at REPLServer.defaultEval (repl.js:240:29)
+//     at bound (domain.js:301:14)
+//     at REPLServer.runBound [as eval] (domain.js:314:12)
+//     at REPLServer.onLine (repl.js:468:10)
+//     at emitOne (events.js:121:20)
+//     at REPLServer.emit (events.js:211:7)
+//     at REPLServer.Interface._onLine (readline.js:282:10)
+//     at REPLServer.Interface._line (readline.js:631:8)
 ```
 
 ### JSON

--- a/errors.js
+++ b/errors.js
@@ -1,0 +1,25 @@
+/* eslint no-undefined: 0 */
+'use strict';
+
+const format = require('./format');
+const { MESSAGE } = require('triple-beam');
+
+/*
+ * function errors (info)
+ * If the `message` property of the `info` object is an instance of `Error`,
+ * replace the `Error` object its own `message` property.
+ *
+ * Optionally, the Error's `stack` property can also be appended to the `info` object.
+ */
+module.exports = format((info, opts) => {
+  if (!(info.message instanceof Error)) return info;
+
+  const err = info.message;
+
+  info.message = err.message;
+  info[MESSAGE] = err.message;
+
+  if (opts.stack) info.stack = err.stack;
+
+  return info;
+});

--- a/index.d.ts
+++ b/index.d.ts
@@ -38,6 +38,7 @@ export namespace format {
   function cli(opts?: CliOptions): Format;
   function colorize(opts?: ColorizeOptions): Colorizer;
   function combine(...formats: Format[]): Format;
+  function errors(opts?: object): Format;
   function json(opts?: JsonOptions): Format;
   function label(opts?: LabelOptions): Format;
   function logstash(): Format;

--- a/index.js
+++ b/index.js
@@ -35,6 +35,7 @@ function exposeFormat(name, path) {
 // Setup all transports as lazy-loaded getters.
 //
 exposeFormat('align');
+exposeFormat('errors');
 exposeFormat('cli');
 exposeFormat('combine');
 exposeFormat('colorize');

--- a/test/errors.test.js
+++ b/test/errors.test.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const assume = require('assume');
+const errors = require('../errors');
+const { assumeFormatted } = require('./helpers');
+const { MESSAGE } = require('triple-beam');
+
+const err = new Error('whatever');
+
+describe('json', () => {
+  it('errors() (default) sets info[MESSAGE]', assumeFormatted(
+    errors(),
+    { level: 'info', message: err },
+    (info) => {
+      assume(info.level).is.a('string');
+      assume(info.message).is.a('string');
+      assume(info.level).equals('info');
+      assume(info.message).equals(err.message);
+      assume(info[MESSAGE]).equals(err.message);
+    }
+  ));
+
+  it('json({ space: 2 }) sets info[MESSAGE]', assumeFormatted(
+    errors({ stack: true }),
+    { level: 'info', message: err },
+    (info) => {
+      assume(info.level).is.a('string');
+      assume(info.message).is.a('string');
+      assume(info.level).equals('info');
+      assume(info.message).equals(err.message);
+      assume(info.stack).equals(err.stack);
+      assume(info[MESSAGE]).equals(err.message);
+    }
+  ));
+});


### PR DESCRIPTION
In winston@2 you used to be able to easily log errors like this: `failingPromise().catch(logger.error)`.

Now, a little object copy prevents that from happening at the transform level: https://github.com/winstonjs/winston-transport/blob/master/index.js#L90

I'm willing to completely re-write what I did if the team thinks that this needs extra features or any changes in general, but I really believe that `logform` should come with a built-in formatter that allows developers to pass in errors to their logger.

(happy to change file names etc too).