### PR TITLE
Add replacer for bigint on json formatter

### DIFF
--- a/json.js
+++ b/json.js
@@ -9,10 +9,11 @@ const jsonStringify = require('fast-safe-stringify');
  * Handles proper stringification of Buffer and bigint output.
  */
 function replacer(key, value) {
-  if (value instanceof Buffer) 
+  if (value instanceof Buffer)
     return value.toString('base64');
-  if (value instanceof bigint)
-     return value.toString();
+  // eslint-disable-next-line valid-typeof
+  if (typeof value === 'bigint')
+    return value.toString();
   return value;
 }
 

--- a/json.js
+++ b/json.js
@@ -6,12 +6,14 @@ const jsonStringify = require('fast-safe-stringify');
 
 /*
  * function replacer (key, value)
- * Handles proper stringification of Buffer output.
+ * Handles proper stringification of Buffer and bigint output.
  */
 function replacer(key, value) {
-  return value instanceof Buffer
-    ? value.toString('base64')
-    : value;
+  if (value instanceof Buffer) 
+    return value.toString('base64');
+  if (value instanceof bigint)
+     return value.toString();
+  return value;
 }
 
 /*


### PR DESCRIPTION
The native bigint type has been available in major browsers and NodeJS for some time now however JSON.stringify requires a custom replacer or it will throw