### PR TITLE
[winston #1606]: stringify info.message in simple formatter

### DIFF
--- a/simple.js
+++ b/simple.js
@@ -24,9 +24,9 @@ module.exports = format(info => {
 
   const padding = info.padding && info.padding[info.level] || '';
   if (stringifiedRest !== '{}') {
-    info[MESSAGE] = `${info.level}:${padding} ${info.message} ${stringifiedRest}`;
+    info[MESSAGE] = `${info.level}:${padding} ${jsonStringify(info.message)} ${stringifiedRest}`;
   } else {
-    info[MESSAGE] = `${info.level}:${padding} ${info.message}`;
+    info[MESSAGE] = `${info.level}:${padding} ${jsonStringify(info.message)}`;
   }
 
   return info;


### PR DESCRIPTION
"Fixes" cases such as the one here where users want `simple` to stringify objects.  Fair enough, "simple" sounds like it should "just work" even if jsonStringify is an extra performance hit.

https://github.com/winstonjs/winston/issues/1606