### PR TITLE
Add option for stable stringifying to JSON (#90)

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,7 @@ It accepts the following options:
 
 * **replacer**: A function that influences how the `info` is stringified.
 * **space**: The number of white space used to format the json.
+* **stable**: If set to `true` the objects' attributes will always be stringified in alphabetical order.
 
 ```js
 const { format } = require('logform');
@@ -383,6 +384,7 @@ const jsonFormat = format.json();
 const info = jsonFormat.transform({
   level: 'info',
   message: 'my message',
+  stable: true,
 });
 console.log(info);
 // { level: 'info',

--- a/json.js
+++ b/json.js
@@ -24,6 +24,7 @@ function replacer(key, value) {
  * to transports in `winston < 3.0.0`.
  */
 module.exports = format((info, opts = {}) => {
-  info[MESSAGE] = jsonStringify(info, opts.replacer || replacer, opts.space);
+  info[MESSAGE] = (opts.stable ? jsonStringify.stableStringify
+    : jsonStringify)(info, opts.replacer || replacer, opts.space);
   return info;
 });


### PR DESCRIPTION
The *JSON* formatter doesn't stringify objects' attributes in a consistent order by default, which is annoying when reading them.

Now we accept a new parameter for that formatter, ***stable***, which when true results in using the *fast-safe-stringify.stableStringify* function, that stringifies attributes in alphabetical order.

*README* has been updated as well.

Closes #90 