### PR TITLE
Fix errors() when err object has an enumerable message prop

### DIFF
--- a/errors.js
+++ b/errors.js
@@ -28,8 +28,8 @@ module.exports = format((einfo, { stack }) => {
 
   // Assign all enumerable properties and the
   // message property from the error provided.
-  Object.assign(einfo, einfo.message);
   const err = einfo.message;
+  Object.assign(einfo, err);
   einfo.message = err.message;
   einfo[MESSAGE] = err.message;
 

--- a/test/errors.test.js
+++ b/test/errors.test.js
@@ -19,6 +19,10 @@ errInfoProps.level = 'error';
 errInfoProps.whatever = true;
 errInfoProps.wut = 'some string';
 
+const errEnumerableMsg = new Error();
+errEnumerableMsg.message = 'message set later';
+errEnumerableMsg.extraProp = 'an extra prop';
+
 describe('errors()({ object })', () => {
   it('errors() returns the original info', assumeFormatted(
     errors(),
@@ -67,6 +71,19 @@ describe('errors()({ object })', () => {
       assume(info[MESSAGE]).equals(errProps.message);
       assume(info.whatever).true();
       assume(info.wut).equals('some string');
+    }
+  ));
+
+  it('errors() still works when err.message is enumerable', assumeFormatted(
+    errors(),
+    { level: 'info', message: errEnumerableMsg },
+    (info) => {
+      assume(info.level).is.a('string');
+      assume(info.message).is.a('string');
+      assume(info.level).equals('info');
+      assume(info.message).equals(errEnumerableMsg.message);
+      assume(info[MESSAGE]).equals(errEnumerableMsg.message);
+      assume(info.extraProp).equals('an extra prop');
     }
   ));
 });


### PR DESCRIPTION
I noticed this while trying to log GraphQL errors. Presumably the way the Error sub-classing works results in an enumerable `message` property.

It seems like this change just brings things in-line with the behavior that you'd expect but let me know if it's not that simple.