### PR TITLE
Replace JSON stringify library "fast-safe-stringify" by "safe-stable-stringify"

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ message. The object itself is mutable. Every `info` must have at least the
 
 ``` js
 const info = {
-  level: 'info',                 // Level of the logging message  
+  level: 'info',                 // Level of the logging message
   message: 'Hey! Log something?' // Descriptive message being logged.
 }
 ```
@@ -57,10 +57,10 @@ const { level, message, ...meta } = info;
 Several of the formats in `logform` itself add additional properties:
 
 | Property    | Format added by | Description |
-| ----------- | --------------- | ----------- | 
+| ----------- | --------------- | ----------- |
 | `splat`     | `splat()`       | String interpolation splat for `%d %s`-style messages. |
 | `timestamp` | `timestamp()`   |  timestamp the message was received. |
-| `label`     | `label()`       | Custom label associated with each message. | 
+| `label`     | `label()`       | Custom label associated with each message. |
 | `ms`        | `ms()`          | Number of milliseconds since the previous log message. |
 
 As a consumer you may add whatever properties you wish – _internal state is
@@ -105,7 +105,7 @@ They are expected to return one of two things:
 - **An `info` Object** representing the modified `info` argument. Object references need not be preserved if immutability is preferred. All current built-in formats consider `info` mutable, but [immutablejs] is being considered for future releases.
 - **A falsey value** indicating that the `info` argument should be ignored by the caller. (See: [Filtering `info` Objects](#filtering-info-objects)) below.
 
-`logform.format`  is designed to be as simple as possible. To define a new format simple pass it a `transform(info, opts)` function to get a new `Format`. 
+`logform.format`  is designed to be as simple as possible. To define a new format simple pass it a `transform(info, opts)` function to get a new `Format`.
 
 The named `Format` returned can be used to create as many copies of the given `Format` as desired:
 
@@ -114,7 +114,7 @@ const { format } = require('logform');
 
 const volume = format((info, opts) => {
   if (opts.yell) {
-    info.message = info.message.toUpperCase(); 
+    info.message = info.message.toUpperCase();
   } else if (opts.whisper) {
     info.message = info.message.toLowerCase();
   }
@@ -135,9 +135,9 @@ console.dir(scream.transform({
 
 // `volume` can be used multiple times to create different formats.
 const whisper = volume({ whisper: true });
-console.dir(whisper.transform({ 
-  level: 'info', 
-  message: `WHY ARE THEY MAKING US YELL SO MUCH!` 
+console.dir(whisper.transform({
+  level: 'info',
+  message: `WHY ARE THEY MAKING US YELL SO MUCH!`
 }), whisper.options);
 // {
 //   level: 'info'
@@ -369,12 +369,11 @@ console.log(info);
 
 ### JSON
 
-The `json` format uses `fast-safe-stringify` to finalize the message.
+The `json` format uses `safe-stable-stringify` to finalize the message.
 It accepts the following options:
 
 * **replacer**: A function that influences how the `info` is stringified.
 * **space**: The number of white space used to format the json.
-* **stable**: If set to `true` the objects' attributes will always be stringified in alphabetical order.
 
 ```js
 const { format } = require('logform');
@@ -384,7 +383,6 @@ const jsonFormat = format.json();
 const info = jsonFormat.transform({
   level: 'info',
   message: 'my message',
-  stable: true,
 });
 console.log(info);
 // { level: 'info',
@@ -494,7 +492,7 @@ This was previously exposed as `{ padLevels: true }` to transports in `winston <
 The `prettyPrint` format finalizes the message using `util.inspect`.
 It accepts the following options:
 
-* **depth**: A `number` that specifies the maximum depth of the `info` object being stringified by `util.inspect`. Defaults to `2`.  
+* **depth**: A `number` that specifies the maximum depth of the `info` object being stringified by `util.inspect`. Defaults to `2`.
 * **colorize**: Colorizes the message if set to `true`. Defaults to `false`.
 
 The `prettyPrint` format should not be used in production because it may impact performance negatively and block the event loop.
@@ -607,11 +605,11 @@ This was previously exposed implicitly in `winston < 3.0.0`.
 
 ### Timestamp
 
-The `timestamp` format adds a timestamp to the info. 
+The `timestamp` format adds a timestamp to the info.
 It accepts the following options:
 
 * **format**: Either the format as a string accepted by the [fecha](https://github.com/taylorhakes/fecha) module or a function that returns a formatted date. If no format is provided `new Date().toISOString()` will be used.
-* **alias**: The name of an alias for the timestamp property, that will be added to the `info` object. 
+* **alias**: The name of an alias for the timestamp property, that will be added to the `info` object.
 
 ```js
 const { format } = require('logform');
@@ -637,9 +635,9 @@ It was previously available in `winston < 3.0.0` as `{ timestamp: true }` and `{
 The `uncolorize` format strips colors from `info` objects.
 It accepts the following options:
 
-* **level**: Disables the uncolorize format for `info.level` if set to `false`. 
-* **message**: Disables the uncolorize format for `info.message` if set to `false`. 
-* **raw**: Disables the uncolorize format for `info[MESSAGE]` if set to `false`. 
+* **level**: Disables the uncolorize format for `info.level` if set to `false`.
+* **message**: Disables the uncolorize format for `info.message` if set to `false`.
+* **raw**: Disables the uncolorize format for `info[MESSAGE]` if set to `false`.
 
 This was previously exposed as `{ stripColors: true }` to transports in `winston < 3.0.0`.
 

--- a/json.js
+++ b/json.js
@@ -2,7 +2,7 @@
 
 const format = require('./format');
 const { MESSAGE } = require('triple-beam');
-const jsonStringify = require('fast-safe-stringify');
+const jsonStringify = require('safe-stable-stringify');
 
 /*
  * function replacer (key, value)
@@ -24,7 +24,6 @@ function replacer(key, value) {
  * to transports in `winston < 3.0.0`.
  */
 module.exports = format((info, opts = {}) => {
-  info[MESSAGE] = (opts.stable ? jsonStringify.stableStringify
-    : jsonStringify)(info, opts.replacer || replacer, opts.space);
+  info[MESSAGE] = jsonStringify(info, opts.replacer || replacer, opts.space);
   return info;
 });

--- a/logstash.js
+++ b/logstash.js
@@ -2,7 +2,7 @@
 
 const format = require('./format');
 const { MESSAGE } = require('triple-beam');
-const jsonStringify = require('fast-safe-stringify');
+const jsonStringify = require('safe-stable-stringify');
 
 /*
  * function logstash (info)

--- a/package-lock.json
+++ b/package-lock.json
@@ -2063,11 +2063,6 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
-    "fast-safe-stringify": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.6.tgz",
-      "integrity": "sha512-q8BZ89jjc+mz08rSxROs8VsrBBcn1SIw1kq9NjolL509tkABRk9io01RAjSaEv1Xb2uFLt8VtRiZbGp5H8iDtg=="
-    },
     "fecha": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
@@ -6840,6 +6835,11 @@
       "requires": {
         "ret": "~0.1.10"
       }
+    },
+    "safe-stable-stringify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-1.1.0.tgz",
+      "integrity": "sha512-8h+96qSufNQrydRPzbHms38VftQQSRGbqUkaIMWUBWN4/N8sLNALIALa8KmFcQ8P/a9uzMkA+KY04Rj5WQiXPA=="
     },
     "safer-buffer": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://github.com/winstonjs/logform#readme",
   "dependencies": {
     "colors": "^1.2.1",
-    "fast-safe-stringify": "^2.0.4",
+    "safe-stable-stringify": "^1.1.0",
     "fecha": "^2.3.3",
     "ms": "^2.1.1",
     "triple-beam": "^1.3.0"

--- a/simple.js
+++ b/simple.js
@@ -3,7 +3,7 @@
 
 const format = require('./format');
 const { MESSAGE } = require('triple-beam');
-const jsonStringify = require('fast-safe-stringify');
+const jsonStringify = require('safe-stable-stringify');
 
 /*
  * function simple (info)

--- a/test/json.test.js
+++ b/test/json.test.js
@@ -2,7 +2,7 @@
 
 const assume = require('assume');
 const json = require('../json');
-const jsonStringify = require('fast-safe-stringify');
+const jsonStringify = require('safe-stable-stringify');
 const { assumeFormatted, assumeHasPrototype, writable } = require('./helpers');
 const { MESSAGE } = require('triple-beam');
 

--- a/test/logstash.test.js
+++ b/test/logstash.test.js
@@ -16,10 +16,10 @@ describe('logstash', () => {
       assume(info.level).equals('info');
       assume(info.message).equals(undefined);
       assume(info[MESSAGE]).equals(JSON.stringify({
-        '@message': expected.message,
         '@fields': {
           level: expected.level
-        }
+        },
+        '@message': expected.message,
       }));
     }
   ));
@@ -34,11 +34,11 @@ describe('logstash', () => {
       assume(info.level).equals('info');
       assume(info.message).equals(undefined);
       assume(info[MESSAGE]).equals(JSON.stringify({
-        '@message': expected.message,
-        '@timestamp': info[TIMESTAMP],
         '@fields': {
           level: expected.level
-        }
+        },
+        '@message': expected.message,
+        '@timestamp': info[TIMESTAMP],
       }));
     }
   ));


### PR DESCRIPTION
Reasons for replacements:

1. It's faster (https://github.com/BridgeAR/safe-stable-stringify#performance--benchmarks)
2. It has less bugs (i also met same bug - https://github.com/davidmarkclements/fast-safe-stringify/issues/46)

From internal tests "safe-stable-stringify" is working faster and still produces correct output.

Only single *disadvantage* - you can't have randomness in property order, it's always **stable**.