### PR TITLE
errors formatter doesn't work if the “message” property is enumerable

### DIFF
--- a/errors.js
+++ b/errors.js
@@ -28,8 +28,8 @@ module.exports = format((einfo, { stack }) => {
 
   // Assign all enumerable properties and the
   // message property from the error provided.
-  Object.assign(einfo, einfo.message);
   const err = einfo.message;
+  Object.assign(einfo, err);
   einfo.message = err.message;
   einfo[MESSAGE] = err.message;
 

--- a/test/errors.test.js
+++ b/test/errors.test.js
@@ -19,6 +19,9 @@ errInfoProps.level = 'error';
 errInfoProps.whatever = true;
 errInfoProps.wut = 'some string';
 
+const errLateMessage = new Error();
+errLateMessage.message = 'whatever';
+
 describe('errors()({ object })', () => {
   it('errors() returns the original info', assumeFormatted(
     errors(),
@@ -67,6 +70,18 @@ describe('errors()({ object })', () => {
       assume(info[MESSAGE]).equals(errProps.message);
       assume(info.whatever).true();
       assume(info.wut).equals('some string');
+    }
+  ));
+
+  it('errors() works with a late-initialized message', assumeFormatted(
+    errors(),
+    { level: 'info', message: errLateMessage },
+    (info) => {
+      assume(info.level).is.a('string');
+      assume(info.message).is.a('string');
+      assume(info.level).equals('info');
+      assume(info.message).equals(errLateMessage.message);
+      assume(info[MESSAGE]).equals(errLateMessage.message);
     }
   ));
 });


### PR DESCRIPTION
Sometimes a library might create a `new Error()` then set its `message` property afterwards. This will make the `message` property enumerable. If you log this through the errors() formatter, you will end up seeing the message 'undefined' because of the way it tries to extract properties from the error object and assumes that 'message' will not be one of them.