### PR TITLE
Fix errors and ms export for browsers

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -21,12 +21,14 @@ exports.levels = require('././levels');
 //
 Object.defineProperty(format, 'align',       { value: require('./align') });
 Object.defineProperty(format, 'cli',         { value: require('./cli') });
-Object.defineProperty(format, 'combine',     { value: require('./combine') });
 Object.defineProperty(format, 'colorize',    { value: require('./colorize') });
+Object.defineProperty(format, 'combine',     { value: require('./combine') });
+Object.defineProperty(format, 'errors',      { value: require('./errors') });
 Object.defineProperty(format, 'json',        { value: require('./json') });
 Object.defineProperty(format, 'label',       { value: require('./label') });
 Object.defineProperty(format, 'logstash',    { value: require('./logstash') });
 Object.defineProperty(format, 'metadata',    { value: require('./metadata') });
+Object.defineProperty(format, 'ms',          { value: require('./ms') });
 Object.defineProperty(format, 'padLevels',   { value: require('./pad-levels') });
 Object.defineProperty(format, 'prettyPrint', { value: require('./pretty-print') });
 Object.defineProperty(format, 'printf',      { value: require('./printf') });


### PR DESCRIPTION
Currently both `errors` and `ms` are not exported when used with browsers, this PR fixes that and makes it possible to use those functions in the browser. I checked, that this is working for my project.

Closes https://github.com/winstonjs/logform/issues/97 and https://github.com/winstonjs/winston/issues/1724.