### PR TITLE
allow to configure util.inspect in splat

### DIFF
--- a/README.md
+++ b/README.md
@@ -563,6 +563,9 @@ console.log(info[MESSAGE]);
 ### Splat
 
 The `splat` format transforms the message by using `util.format` to complete any `info.message` provided it has string interpolation tokens.
+It accepts the following options:
+
+* **inspectOptions**: Option object that is passed to `util.inspect` when finalizing the message.
 
 ```js
 const { format } = require('logform');

--- a/splat.js
+++ b/splat.js
@@ -19,7 +19,7 @@ const escapedPercent = /%%/g;
 
 class Splatter {
   constructor(opts) {
-    this.options = opts;
+    this.options = opts || {};
   }
 
   /**
@@ -68,7 +68,11 @@ class Splatter {
       }
     }
 
-    info.message = util.format(msg, ...splat);
+    if (this.options.inspectOptions) {
+      info.message = util.formatWithOptions(this.options.inspectOptions, msg, ...splat);
+    } else {
+      info.message = util.format(msg, ...splat);
+    }
     return info;
   }
 

--- a/test/splat.test.js
+++ b/test/splat.test.js
@@ -10,9 +10,9 @@ const helpers = require('./helpers');
  * with the given { message, splat: spread } is properly interoplated
  * by the splat format into the `expected` value.
  */
-function assumeSplat(message, spread, expected) {
+function assumeSplat(message, spread, expected, options) {
   return helpers.assumeFormatted(
-    splat(),
+    splat(options),
     { level: 'info', message, [SPLAT]: spread },
     info => {
       assume(info.level).is.a('string');
@@ -29,7 +29,7 @@ function assumeSplat(message, spread, expected) {
   );
 }
 
-describe('splat', () => {
+describe('splat', () => { // eslint-disable-line max-statements
   it('basic string', assumeSplat(
     'just a string', [], 'just a string'
   ));
@@ -104,6 +104,23 @@ describe('splat', () => {
       assume(info.message).equals('Hi #42, how are you feeling');
       assume(info.today).true();
     }
+  ));
+
+  it('%O | object placeholder formats object', assumeSplat(
+    'printing object %O',
+    [{ hello: 'world' }],
+    info => {
+      assume(info.message).equals('printing object { hello: \'world\' }');
+    }
+  ));
+
+  it('%O | object placeholder formats deep object', assumeSplat(
+    'printing object %O',
+    [{ a: { b: { c: { d: { e: { f: 1 }}}}}}],
+    info => {
+      assume(info.message).equals(`printing object {\n  a: {\n    b: {\n      c: { d: { e: { f: 1 } } }\n    }\n  }\n}`);
+    },
+    { inspectOptions: { depth: null }}
   ));
 
   it('No [SPLAT] does not crash', () => {


### PR DESCRIPTION
Allows to pass configuration to `util.inspect` in splat formatter.
For example passing `{ deep: null }` allows us to print deep properties of objects.