### PR TITLE
fix: Include stacktrace into error message

### DIFF
--- a/errors.js
+++ b/errors.js
@@ -9,7 +9,8 @@ const { LEVEL, MESSAGE } = require('triple-beam');
  * If the `message` property of the `info` object is an instance of `Error`,
  * replace the `Error` object its own `message` property.
  *
- * Optionally, the Error's `stack` property can also be appended to the `info` object.
+ * Optionally, the Error's `stack` property can also be appended to the `message` property.
+ * For backward compatibility also include stack property into info object.
  */
 module.exports = format((einfo, { stack }) => {
   if (einfo instanceof Error) {
@@ -20,7 +21,12 @@ module.exports = format((einfo, { stack }) => {
       [MESSAGE]: einfo[MESSAGE] || einfo.message
     });
 
-    if (stack) info.stack = einfo.stack;
+    if (stack) {
+      info[MESSAGE] += '\n' + einfo.stack;
+      info.message = info[MESSAGE];
+      info.stack = einfo.stack;
+    }
+
     return info;
   }
 
@@ -34,6 +40,11 @@ module.exports = format((einfo, { stack }) => {
   einfo[MESSAGE] = err.message;
 
   // Assign the stack if requested.
-  if (stack) einfo.stack = err.stack;
+  if (stack) {
+    einfo[MESSAGE] += '\n' + err.stack;
+    einfo.message = einfo[MESSAGE];
+    einfo.stack = err.stack;
+  }
+
   return einfo;
 });

--- a/test/errors.test.js
+++ b/test/errors.test.js
@@ -53,8 +53,8 @@ describe('errors()({ object })', () => {
       assume(info.level).is.a('string');
       assume(info.message).is.a('string');
       assume(info.level).equals('info');
-      assume(info.message).equals(err.message);
-      assume(info[MESSAGE]).equals(err.message);
+      assume(info.message).equals(err.message + '\n' + err.stack);
+      assume(info[MESSAGE]).equals(err.message + '\n' + err.stack);
       assume(info.stack).equals(err.stack);
     }
   ));
@@ -100,15 +100,15 @@ describe('errors()(Error)', () => {
     { immutable: false }
   ));
 
-  it('errors({ space: 2 }) sets info.stack', assumeFormatted(
+  it('errors({ stack: true }) includes error stack into message.', assumeFormatted(
     errors({ stack: true }),
     errInfo,
     (info) => {
       assume(info.level).is.a('string');
       assume(info.message).is.a('string');
       assume(info.level).equals(errInfo.level);
-      assume(info.message).equals(errInfo.message);
-      assume(info[MESSAGE]).equals(errInfo.message);
+      assume(info.message).equals(errInfo.message + '\n' + errInfo.stack);
+      assume(info[MESSAGE]).equals(errInfo.message + '\n' + errInfo.stack);
       assume(info.stack).equals(errInfo.stack);
     },
     { immutable: false }


### PR DESCRIPTION
### The problem
Log format `errors` actually confuses users. When a user specifies `stack: true` he or she expects that the stack trace will be included into the message, but it does not. For instance, this issue is a great example of such confusion https://github.com/winstonjs/winston/issues/1498

Because we are not appending the message to the `info.message` and `info[MESSAGE]` some formatted may not show the actual stack trace, for example, `simple`.
### Solution
The easy way is to append the stack trace to the `info.message` and `info[MESSAGE]` if `stack: true`, and leave `info.stack = stack` for backward compatibility with other code that was written so far