### PR TITLE
Logstash format handler removes message and timestamp from info potentially breaking  subsequent formatters

### DIFF
--- a/logstash.js
+++ b/logstash.js
@@ -12,18 +12,17 @@ const jsonStringify = require('safe-stable-stringify');
  * to transports in `winston < 3.0.0`.
  */
 module.exports = format(info => {
-  const logstash = {};
-  if (info.message) {
-    logstash['@message'] = info.message;
-    delete info.message;
+  const { message, timestamp, ...fields } = info;
+  const logstash = {'@fields': fields};
+
+  if (message) {
+    logstash['@message'] = message;
   }
 
-  if (info.timestamp) {
-    logstash['@timestamp'] = info.timestamp;
-    delete info.timestamp;
+  if (timestamp) {
+    logstash['@timestamp'] = timestamp;
   }
 
-  logstash['@fields'] = info;
   info[MESSAGE] = jsonStringify(logstash);
   return info;
 });


### PR DESCRIPTION
One of my transports have it's own format handler which broke after I switched winston to logstash format. It seems like a bug in logstash format handler.

Here is a possible solution.