### PR TITLE
Fix dynamic imports for rollup

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,39 +15,122 @@ const format = exports.format = require('./format');
  */
 exports.levels = require('./levels');
 
-/*
- * @api private
- * method {function} exposeFormat
- * Exposes a sub-format on the main format object
- * as a lazy-loaded getter.
- */
-function exposeFormat(name, path) {
-  path = path || name;
-  Object.defineProperty(format, name, {
-    get() {
-      return require(`./${path}.js`);
-    },
-    configurable: true
-  });
-}
 
-//
-// Setup all transports as lazy-loaded getters.
-//
-exposeFormat('align');
-exposeFormat('errors');
-exposeFormat('cli');
-exposeFormat('combine');
-exposeFormat('colorize');
-exposeFormat('json');
-exposeFormat('label');
-exposeFormat('logstash');
-exposeFormat('metadata');
-exposeFormat('ms');
-exposeFormat('padLevels', 'pad-levels');
-exposeFormat('prettyPrint', 'pretty-print');
-exposeFormat('printf');
-exposeFormat('simple');
-exposeFormat('splat');
-exposeFormat('timestamp');
-exposeFormat('uncolorize');
+Object.defineProperty(format, 'align', {
+  get() {
+    return require('./align');
+  },
+  configurable: true
+});
+
+Object.defineProperty(format, 'errors', {
+  get() {
+    return require('./errors');
+  },
+  configurable: true
+});
+
+Object.defineProperty(format, 'cli', {
+  get() {
+    return require('./cli');
+  },
+  configurable: true
+});
+
+Object.defineProperty(format, 'combine', {
+  get() {
+    return require('./combine');
+  },
+  configurable: true
+});
+
+Object.defineProperty(format, 'colorize', {
+  get() {
+    return require('./colorize');
+  },
+  configurable: true
+});
+
+Object.defineProperty(format, 'json', {
+  get() {
+    return require('./json');
+  },
+  configurable: true
+});
+
+Object.defineProperty(format, 'label', {
+  get() {
+    return require('./label');
+  },
+  configurable: true
+});
+
+Object.defineProperty(format, 'logstash', {
+  get() {
+    return require('./logstash');
+  },
+  configurable: true
+});
+
+Object.defineProperty(format, 'metadata', {
+  get() {
+    return require('./metadata');
+  },
+  configurable: true
+});
+
+Object.defineProperty(format, 'ms', {
+  get() {
+    return require('./ms');
+  },
+  configurable: true
+});
+
+Object.defineProperty(format, 'padLevels', {
+  get() {
+    return require('./pad-levels');
+  },
+  configurable: true
+});
+
+Object.defineProperty(format, 'prettyPrint', {
+  get() {
+    return require('./pretty-print');
+  },
+  configurable: true
+});
+
+Object.defineProperty(format, 'printf', {
+  get() {
+    return require('./printf');
+  },
+  configurable: true
+});
+
+Object.defineProperty(format, 'simple', {
+  get() {
+    return require('./simple');
+  },
+  configurable: true
+});
+
+Object.defineProperty(format, 'splat', {
+  get() {
+    return require('./splat');
+  },
+  configurable: true
+});
+
+Object.defineProperty(format, 'timestamp' ,{
+  get() {
+    return require('./timestamp');
+  },
+  configurable: true
+});
+
+Object.defineProperty(format, 'uncolorize', {
+  get() {
+    return require('./uncolorize');
+  },
+  configurable: true
+});


### PR DESCRIPTION
Rollup isn't able to bundle Winston because of dynamic imports here https://github.com/winstonjs/logform/blob/master/index.js#L27

Reverting https://github.com/winstonjs/logform/commit/972dbece432dbda7a0aeae4c4a7ac8d549821a78#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346R24 should fix the problem.

Related Issues: 
https://github.com/winstonjs/logform/issues/5
https://github.com/winstonjs/logform/issues/119 