### PR TITLE
Pin colors package to 1.4.0 due to Security Vuln

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/winstonjs/logform#readme",
   "dependencies": {
-    "colors": "^1.2.1",
+    "colors": "1.4.0",
     "safe-stable-stringify": "^1.1.0",
     "fecha": "^4.2.0",
     "ms": "^2.1.1",


### PR DESCRIPTION
related to [PR in Winston](https://github.com/winstonjs/winston/pull/2008/files),

This PR pins colors to 1.4.0 (which respects the previous semver range in ^1.2.0) to mitigate an identified security vulnerability in `colors@1.4.4` and `colors@1.4.44-liberty`)

@DABH , when you have a moment, would you kindly review?