### PR TITLE
Update to @colors/colors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.3.2",
       "license": "MIT",
       "dependencies": {
-        "colors": "1.4.0",
+        "@colors/colors": "1.5.0",
         "fecha": "^4.2.0",
         "ms": "^2.1.1",
         "safe-stable-stringify": "^1.1.0",
@@ -1220,6 +1220,14 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "node_modules/@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
     "node_modules/@dabh/eslint-config-populist": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@dabh/eslint-config-populist/-/eslint-config-populist-5.0.0.tgz",
@@ -1868,14 +1876,6 @@
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
       "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
       "dev": true
-    },
-    "node_modules/colors": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-      "engines": {
-        "node": ">=0.1.90"
-      }
     },
     "node_modules/commander": {
       "version": "4.1.1",
@@ -6147,6 +6147,11 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="
+    },
     "@dabh/eslint-config-populist": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@dabh/eslint-config-populist/-/eslint-config-populist-5.0.0.tgz",
@@ -6651,11 +6656,6 @@
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
       "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
       "dev": true
-    },
-    "colors": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
     },
     "commander": {
       "version": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/winstonjs/logform#readme",
   "dependencies": {
-    "colors": "1.4.0",
+    "@colors/colors": "1.5.0",
     "fecha": "^4.2.0",
     "ms": "^2.1.1",
     "safe-stable-stringify": "^1.1.0",


### PR DESCRIPTION
The `colors` package has been renamed/moved to `@colors/colors` per https://github.com/Marak/colors.js/issues/340.