### PR TITLE
fix: crash on attempt to uncolorize Symbol

### DIFF
--- a/test/uncolorize.test.js
+++ b/test/uncolorize.test.js
@@ -83,6 +83,25 @@ describe('uncolorize', () => {
     }
   ));
 
+  it('uncolorize() not crashing with Symbol()', assumeFormatted(
+    combine(
+      format(info => {
+        info.level = info.level.toUpperCase();
+        return info;
+      })(),
+      colorize(),
+      uncolorize()
+    ),
+    infoify({ level: 'info', message: Symbol() }),
+    info => {
+      assume(info.level).is.a('string');
+      assume(info.message).is.a('string');
+
+      assume(info.level).equals('INFO');
+      assume(info.message).equals('Symbol()');
+    }
+  ));
+
   it('uncolorize({ level: false }) removes color from { message, [MESSAGE] }', assumeFormatted(
     addAndRemoveColors({ level: false }),
     infoify({ level: 'info', message: 'whatever' }),

--- a/uncolorize.js
+++ b/uncolorize.js
@@ -16,11 +16,11 @@ module.exports = format((info, opts) => {
   }
 
   if (opts.message !== false) {
-    info.message = colors.strip(info.message);
+    info.message = colors.strip(String(info.message));
   }
 
   if (opts.raw !== false && info[MESSAGE]) {
-    info[MESSAGE] = colors.strip(info[MESSAGE]);
+    info[MESSAGE] = colors.strip(String(info[MESSAGE]));
   }
 
   return info;


### PR DESCRIPTION
The `.strip` method of `@colors/colors/safe` is crashing when obtaining Symbol. According to its type definitions, non-strings are not supported. This PR would ensure that only string is provided.

The provided test is crashing without the fix, just as expected.

Tested also with `winston` - without the fix, usage of `uncolorize` with Symbol is crashing