### PR TITLE
Feature - optionally include Error.cause property

### DIFF
--- a/errors.js
+++ b/errors.js
@@ -9,9 +9,9 @@ const { LEVEL, MESSAGE } = require('triple-beam');
  * If the `message` property of the `info` object is an instance of `Error`,
  * replace the `Error` object its own `message` property.
  *
- * Optionally, the Error's `stack` property can also be appended to the `info` object.
+ * Optionally, the Error's `stack` and/or `cause` properties can also be appended to the `info` object.
  */
-module.exports = format((einfo, { stack }) => {
+module.exports = format((einfo, { stack, cause }) => {
   if (einfo instanceof Error) {
     const info = Object.assign({}, einfo, {
       level: einfo.level,
@@ -21,6 +21,7 @@ module.exports = format((einfo, { stack }) => {
     });
 
     if (stack) info.stack = einfo.stack;
+    if (cause) info.cause = einfo.cause;
     return info;
   }
 
@@ -33,7 +34,8 @@ module.exports = format((einfo, { stack }) => {
   einfo.message = err.message;
   einfo[MESSAGE] = err.message;
 
-  // Assign the stack if requested.
+  // Assign the stack and/or cause if requested.
   if (stack) einfo.stack = err.stack;
+  if (cause) einfo.cause = err.cause;
   return einfo;
 });

--- a/test/errors.test.js
+++ b/test/errors.test.js
@@ -22,6 +22,8 @@ errInfoProps.wut = 'some string';
 const errLateMessage = new Error();
 errLateMessage.message = 'whatever';
 
+const errWithCause = new Error('wut', { cause: new Error('an error cause') });
+
 describe('errors()({ object })', () => {
   it('errors() returns the original info', assumeFormatted(
     errors(),
@@ -82,6 +84,33 @@ describe('errors()({ object })', () => {
       assume(info.level).equals('info');
       assume(info.message).equals(errLateMessage.message);
       assume(info[MESSAGE]).equals(errLateMessage.message);
+    }
+  ));
+
+  it('errors({ cause: true }) sets info.cause', assumeFormatted(
+    errors({ cause: true }),
+    { level: 'info', message: errWithCause },
+    (info) => {
+      assume(info.level).is.a('string');
+      assume(info.message).is.a('string');
+      assume(info.level).equals('info');
+      assume(info.message).equals(errWithCause.message);
+      assume(info[MESSAGE]).equals(errWithCause.message);
+      assume(info.cause).equals(errWithCause.cause);
+    }
+  ));
+
+  it('errors({ stack: true, cause: true }) sets info.stack and info.cause', assumeFormatted(
+    errors({ stack: true, cause: true }),
+    { level: 'info', message: errWithCause },
+    (info) => {
+      assume(info.level).is.a('string');
+      assume(info.message).is.a('string');
+      assume(info.level).equals('info');
+      assume(info.message).equals(errWithCause.message);
+      assume(info[MESSAGE]).equals(errWithCause.message);
+      assume(info.stack).equals(errWithCause.stack);
+      assume(info.cause).equals(errWithCause.cause);
     }
   ));
 });


### PR DESCRIPTION
This would extend the options (currently {stack: Boolean}) to include a "cause" option.  Passing cause: true would make the emitted info include the Error.cause property and allow the fullest error logging for users who are using error causes.

I wasn't sure if the conditionals should be `if (cause)` or `if (cause && einfo.cause)`.  I'd be very happy with either.

For background, Error.cause is an ES2022 addition, added to node in 16.9.0.