### PR TITLE
TransformableInfo should support symbols as keys

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,7 +7,7 @@
 export interface TransformableInfo {
   level: string;
   message: any;
-  [key: string]: any;
+  [key: string | symbol]: any;
 }
 
 export type TransformFunction = (info: TransformableInfo, opts?: any) => TransformableInfo | boolean;


### PR DESCRIPTION
Being able to use a Symbol as a key for TransformableInfo makes it easier to create cleaner transforms.

The current typing forbids this, so this change enables it.