### PR TITLE
fix: expose types dependency we depend on

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@colors/colors": "1.5.0",
+        "@types/triple-beam": "^1.3.2",
         "fecha": "^4.2.0",
         "ms": "^2.1.1",
         "safe-stable-stringify": "^2.3.1",
@@ -20,7 +21,6 @@
         "@babel/core": "^7.10.3",
         "@babel/preset-env": "^7.10.3",
         "@dabh/eslint-config-populist": "^5.0.0",
-        "@types/triple-beam": "^1.3.2",
         "assume": "^2.2.0",
         "eslint": "^8.8.0",
         "mocha": "^10.0.0",
@@ -2007,8 +2007,7 @@
     "node_modules/@types/triple-beam": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.2.tgz",
-      "integrity": "sha512-txGIh+0eDFzKGC25zORnswy+br1Ha7hj5cMVwKIU7+s0U2AxxJru/jZSMU6OC9MJWP6+pc/hc6ZjyZShpsyY2g==",
-      "dev": true
+      "integrity": "sha512-txGIh+0eDFzKGC25zORnswy+br1Ha7hj5cMVwKIU7+s0U2AxxJru/jZSMU6OC9MJWP6+pc/hc6ZjyZShpsyY2g=="
     },
     "node_modules/acorn": {
       "version": "8.8.2",
@@ -7063,8 +7062,7 @@
     "@types/triple-beam": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.2.tgz",
-      "integrity": "sha512-txGIh+0eDFzKGC25zORnswy+br1Ha7hj5cMVwKIU7+s0U2AxxJru/jZSMU6OC9MJWP6+pc/hc6ZjyZShpsyY2g==",
-      "dev": true
+      "integrity": "sha512-txGIh+0eDFzKGC25zORnswy+br1Ha7hj5cMVwKIU7+s0U2AxxJru/jZSMU6OC9MJWP6+pc/hc6ZjyZShpsyY2g=="
     },
     "acorn": {
       "version": "8.8.2",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "homepage": "https://github.com/winstonjs/logform#readme",
   "dependencies": {
     "@colors/colors": "1.5.0",
+    "@types/triple-beam": "^1.3.2",
     "fecha": "^4.2.0",
     "ms": "^2.1.1",
     "safe-stable-stringify": "^2.3.1",
@@ -39,7 +40,6 @@
     "@babel/core": "^7.10.3",
     "@babel/preset-env": "^7.10.3",
     "@dabh/eslint-config-populist": "^5.0.0",
-    "@types/triple-beam": "^1.3.2",
     "assume": "^2.2.0",
     "eslint": "^8.8.0",
     "mocha": "^10.0.0",


### PR DESCRIPTION
Simple solution to #242 : Mark the types we use as dependency.

simply running `npm i @types/triple-beam` in any of my failed projects fixes it.