### PR TITLE
Adding mask formatting example

### DIFF
--- a/examples/mask.js
+++ b/examples/mask.js
@@ -1,0 +1,62 @@
+const { format } = require('../');
+
+const apiResponse = {
+  creditCard: 1111222233334444,
+  ssn: 4873945739834,
+  customer: {
+    firstName: 'Jim',
+    lastName: 'Davis',
+    address: {
+      number: '404',
+      street: 'Poughkeepsie Lane',
+      city: 'Alpharetta',
+      state: 'GA'
+    }
+  },
+  accounts: [
+    {
+      bank: 'Bank of America',
+      accountNumber: 1290382430
+    },
+    {
+      bank: 'Chase',
+      accountNumber: 423523235
+    },
+    {
+      bank: 'Wells Fargo',
+      accountNumber: 1554235555235460
+    }
+  ]
+};
+
+const maskDataFormat = format((info) => {
+  const mask = (data, maskCharactersVisible = 0, maskCharacter = '*') => {
+    Object.keys(data).forEach((key) => {
+      const strKey = `${data[key]}`;
+      const strLength = strKey.length;
+      if ((typeof data[key] === 'object' || Array.isArray(key)) && data[key]) {
+        mask(data[key], maskCharactersVisible, maskCharacter);
+      } else if (key === 'accountNumber' || key === 'creditCard') {
+        if (maskCharactersVisible > 0 && maskCharactersVisible < strLength) {
+          data[key] =
+                  maskCharacter.repeat(
+                    strKey.slice(0, strLength - maskCharactersVisible).length
+                  ) + strKey.slice(strLength - maskCharactersVisible);
+        } else {
+          data[key] = maskCharacter.repeat(strLength);
+        }
+      }
+    });
+
+    return data;
+  };
+
+  mask(info.message, 4, '%');
+  return info;
+});
+const mdf = maskDataFormat();
+
+console.dir(mdf.transform({
+  level: 'info',
+  message: apiResponse
+}));


### PR DESCRIPTION
Including a formatting example for masking data with a common use case of customizing how many characters to mask and the character to use for replacing.

Very dependent on particular object property key names, but could possibly be combined with regex expressions for common PII/PCI/PHI data formats.

Inspired by [feature request 2116](https://github.com/winstonjs/winston/issues/2116) from winstonjs/winston.