### PR TITLE
perf: update ms to use performance.now() for more accurate time measurements

### DIFF
--- a/ms.js
+++ b/ms.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { performance } = require('perf_hooks');
 const format = require('./format');
 const ms = require('ms');
 
@@ -8,11 +9,11 @@ const ms = require('ms');
  * Returns an `info` with a `ms` property. The `ms` property holds the Value
  * of the time difference between two calls in milliseconds.
  */
-module.exports = format(info => {
-  const curr = +new Date();
+module.exports = format((info) => {
+  const curr = performance.now();
   this.diff = curr - (this.prevTime || curr);
   this.prevTime = curr;
-  info.ms = `+${ms(this.diff)}`;
+  info.ms = `+${ms(Math.round(this.diff))}`;
 
   return info;
 });


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?

The current behavior is implemented using the `+new Date()` method to calculate the time difference between two calls.


## What is the new behavior?

The new behavior replaces the usage of `+new Date()` with the more accurate `performance.now()` method to calculate the time difference between two calls.


## Does this introduce a breaking change?

- [ ] Yes
- [x] No


## Other information
The code changes include replacing `+new Date()` with `performance.now()` for more accurate time measurements.