### PR TITLE
Add option to wholesale replace the timestamp property with another

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -183,6 +183,10 @@ export interface TimestampOptions {
    * The name of an alias for the timestamp property, that will be added to the `info` object.
    */
   alias?: string;
+  /**
+   * The name of the timestamp property, that will take the place of "timestamp" if specified.
+   */
+  propName?: string;
 }
 
 export interface UncolorizeOptions {

--- a/timestamp.js
+++ b/timestamp.js
@@ -11,19 +11,19 @@ const format = require('./format');
  * - { timestamp: true }             // `new Date.toISOString()`
  * - { timestamp: function:String }  // Value returned by `timestamp()`
  */
-module.exports = format((info, opts = {}) => {
+module.exports = format((info, opts = {propName: 'timestamp'}) => {
   if (opts.format) {
-    info.timestamp = typeof opts.format === 'function'
+    info[opts.propName] = typeof opts.format === 'function'
       ? opts.format()
       : fecha.format(new Date(), opts.format);
   }
 
-  if (!info.timestamp) {
-    info.timestamp = new Date().toISOString();
+  if (!info[propName]) {
+    info[opts.propName] = new Date().toISOString();
   }
 
   if (opts.alias) {
-    info[opts.alias] = info.timestamp;
+    info[opts.alias] = info[opts.propName];
   }
 
   return info;


### PR DESCRIPTION
Alias is not enough if your application routinely also uses timestamp for something else.