### PR TITLE
Update index.d.ts to support multiple color entries

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -75,7 +75,7 @@ export interface ColorizeOptions {
   /**
    * An object containing the colors for the log levels. For example: `{ info: 'blue', error: 'red' }`.
    */
-  colors?: Record<string, string>;
+  colors?: Record<string, string | string[]>;
 }
 
 export interface JsonOptions {


### PR DESCRIPTION
The colorize format supports passing in arrays of colors/styles for individual colors. The typescript needs to be updated to match the code.