### PR TITLE
fix: Update index.d.ts to improve JsonOptions.deterministic typing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -106,9 +106,11 @@ export interface JsonOptions {
   circularValue?: string | null | TypeErrorConstructor | ErrorConstructor,
   /**
    * If `true`, guarantee a deterministic key order instead of relying on the insertion order.
+   * Set to `false` to keep original insertion order.
+   * Or provide an array comparator function that determines the order of the elements. 
    * @default true
    */
-  deterministic?: boolean,
+  deterministic?: boolean | ((a: string, b: string) => number),
   /**
    * Maximum number of entries to serialize per object (at least one).
    * The serialized output contains information about how many entries have not been serialized.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@types/triple-beam": "^1.3.2",
         "fecha": "^4.2.0",
         "ms": "^2.1.1",
-        "safe-stable-stringify": "^2.3.1",
+        "safe-stable-stringify": "^2.5.0",
         "triple-beam": "^1.3.0"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@types/triple-beam": "^1.3.2",
     "fecha": "^4.2.0",
     "ms": "^2.1.1",
-    "safe-stable-stringify": "^2.3.1",
+    "safe-stable-stringify": "^2.5.0",
     "triple-beam": "^1.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Allow creating json formatter with function passed as deterministic comparator.

---

- Improve typing of `JsonOptions.deterministic` to reflect underlying type and allow passing in the comparator.
- Bump `safe-stable-stringify` to latest version explicitly (`deterministic` option supported from 2.5.0 ([ref](https://github.com/BridgeAR/safe-stable-stringify/releases))

Note: With previous `package.json` version selector `^2.3.1` we were installing version `2.5.0` anyway, so the bump in package.json is just to make this explicit.