### PR TITLE
fix: exclude %c from splat format specifiers

### DIFF
--- a/splat.js
+++ b/splat.js
@@ -9,7 +9,7 @@ const { SPLAT } = require('triple-beam');
  * https://github.com/nodejs/node/blob/b1c8f15c5f169e021f7c46eb7b219de95fe97603/lib/util.js#L201-L230
  * @type {RegExp}
  */
-const formatRegExp = /%[scdjifoO%]/g;
+const formatRegExp = /%[sdjifoO%]/g;
 
 /**
  * Captures the number of escaped % signs in a format string (i.e. %s strings).

--- a/test/splat.test.js
+++ b/test/splat.test.js
@@ -136,4 +136,23 @@ describe('splat', () => {
     );
   });
 
+
+  it('%c in message with meta | preserves %c and merges meta', assumeSplat(
+    'hello %c world', [{ robotId: 5 }], info => {
+      assume(info.message).equals('hello %c world');
+      assume(info.robotId).equals(5);
+    }
+  ));
+
+  it('%c in message without meta | preserves %c in message', assumeSplat(
+    'hello %c world', [], 'hello %c world'
+  ));
+
+  it('%c mixed with valid specifiers | only interpolates valid specifiers', assumeSplat(
+    'hello %s %c world', ['test', { robotId: 5 }], info => {
+      assume(info.message).equals('hello test %c world');
+      assume(info.robotId).equals(5);
+    }
+  ));
+
 });


### PR DESCRIPTION
When a log message contains `%c` (a CSS styling directive for browser consoles), the splat format incorrectly treats it as a format token. This causes two problems:

1. `%c` gets swallowed from the message (since `util.format` replaces it with empty string in Node.js)
2. Trailing metadata objects get consumed as format arguments instead of being merged into the log info

For example:
```js
logger.info('hello %c world', { robotId: 5 });
// Before fix: {"level":"info","message":"hello  world"}        (robotId lost, %c gone)
// After fix:  {"level":"info","message":"hello %c world","robotId":5}
```

The fix removes `c` from the `formatRegExp` regex since `%c` is not a meaningful data format specifier in Node.js — it's a browser console CSS styling directive that produces empty output with `util.format`.

All existing tests still pass, and I added three new test cases covering `%c` handling:
- `%c` in message with a trailing meta object
- `%c` in message without meta
- `%c` mixed with valid specifiers like `%s`

Fixes winstonjs/winston#2572