### PR TITLE
fix(pad-levels): guard against undefined padding for unknown levels

### DIFF
--- a/pad-levels.js
+++ b/pad-levels.js
@@ -61,9 +61,10 @@ class Padder {
    * @returns {Info} Modified logform info object.
    */
   transform(info, opts) {
-    info.message = `${this.paddings[info[LEVEL]]}${info.message}`;
+    const padding = this.paddings[info[LEVEL]] || '';
+    info.message = `${padding}${info.message}`;
     if (info[MESSAGE]) {
-      info[MESSAGE] = `${this.paddings[info[LEVEL]]}${info[MESSAGE]}`;
+      info[MESSAGE] = `${padding}${info[MESSAGE]}`;
     }
 
     return info;

--- a/test/pad-levels.test.js
+++ b/test/pad-levels.test.js
@@ -51,6 +51,15 @@ describe('padLevels', () => {
     }
   ));
 
+  it('padLevels does not prepend "undefined" for levels not in the padding map', assumeFormatted(
+    padLevels({ levels: configs.npm.levels }),
+    infoify({ level: 'emerg', message: 'custom level message' }),
+    info => {
+      assume(info.message).equals('custom level message');
+      assume(info[MESSAGE]).equals('custom level message');
+    }
+  ));
+
   it('exposes the Format prototype', assumeHasPrototype(padLevels));
 });
 


### PR DESCRIPTION
When a logger uses custom levels (e.g. \`config.syslog.levels\`) but the \`padLevels\` format is initialized with a different level set, \`this.paddings[info[LEVEL]]\` is \`undefined\`. This gets coerced to the string \`"undefined"\` and prepended to every log message.

Defensive fix: default to \`""\` when a level is missing from the padding map.

Fixes the behavior reported in https://github.com/winstonjs/winston/issues/2477 where using \`format.cli()\` with syslog levels produces output like `emerg:undefinedHello World!`.