### PR TITLE
docs: fix filtering example to instantiate format before calling .transform()

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,13 +180,13 @@ const ignorePrivate = format((info, opts) => {
   return info;
 });
 
-console.dir(ignorePrivate.transform({
+console.dir(ignorePrivate().transform({
   level: 'error',
   message: 'Public error to share'
 }));
 // { level: 'error', message: 'Public error to share' }
 
-console.dir(ignorePrivate.transform({
+console.dir(ignorePrivate().transform({
   level: 'error',
   private: true,
   message: 'This is super secret - hide it.'


### PR DESCRIPTION
Fixes #347.

The "Filtering info Objects" example in the README calls `.transform()` directly on the format factory (`ignorePrivate.transform(…)`), but `format(fn)` returns a factory function — not a format instance. The factory must be called first to create an instance.

Changed both `ignorePrivate.transform(…)` calls to `ignorePrivate().transform(…)`, consistent with the volume/scream/whisper examples earlier in the same README which correctly instantiate the format with `volume({ yell: true })`.