### PR TITLE
ci: upgrade test matrix to Node 22, 24, and 26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,9 @@ jobs:
     strategy:
       matrix:
         node:
-          - 16
-          - 18
-          - 20
+          - 22
+          - 24
+          - 26
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,6 @@
     "noImplicitThis": true,
     "strictNullChecks": true,
     "strictFunctionTypes": true,
-    "baseUrl": "../",
     "typeRoots": [
       "../"
     ],


### PR DESCRIPTION
Upgrades the CI test matrix to exercise currently-supported Node.js releases.

## Changes
- Test matrix: Node `16, 18, 20` → `22, 24, 26`. The previous versions are all past end-of-life.
- Removes the deprecated, unused `baseUrl` from `tsconfig.json`. The CI **TypeScript Test** step runs the latest `tsc` (now 6.0), which errors on `baseUrl` (`TS5101`). It had no `paths` map relying on it (and `types: []` means no ambient types are loaded anyway), so removing it keeps the type-check green without changing behavior.

## Verification
`npm run lint`, `npm test`, and `npx tsc` all pass locally on Node **22, 24, and 26**.